### PR TITLE
[BOUNTY] Compliance Implant

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -59,6 +59,7 @@
 #define ROLE_REVENANT "Revenant"
 #define ROLE_BRAINWASHED "Brainwashed Victim"
 #define ROLE_HYPNOTIZED "Hypnotized Victim"
+#define ROLE_COMPLIANT "Compliance Implanted"
 #define ROLE_OVERTHROW "Syndicate Mutineer" //Role removed, left here for safety.
 #define ROLE_HIVE "Hivemind Host" //Role removed, left here for safety.
 #define ROLE_SENTIENCE "Sentience Potion Spawn"

--- a/code/game/objects/items/implants/implant_compliance.dm
+++ b/code/game/objects/items/implants/implant_compliance.dm
@@ -1,0 +1,61 @@
+/obj/item/implant/compliance
+	name = "compliance implant"
+	actions_types = null
+	/// What company is this implant calibrated for?
+	var/company = "Nanotrasen"
+	/// What department is this implant calibrated for?
+	var/department = "Security"
+	/// (Emagged Only) - What person is this implant calibrated for?
+	var/calibrated_person = "John Doe"
+	/// The finished brainwash message.
+	var/brainwash_message = "You feel inclined to contact a technical support representative..."
+
+/obj/item/implant/compliance/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Compliance Implant<BR>
+				<b>Life:</b> Immediately self-destructs upon payload delivery.<BR>
+				"}
+	return dat
+
+/obj/item/implant/compliance/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
+	if(obj_flags & EMAGGED)
+		brainwash_message = "Whispers in the back of your skull make you feel uneasy, make you feel wrong. Yet, the whispers cease as [calibrated_person] \
+							is near, a light in the darkness. There's an incessant, nagging thankfulness in you as you think of them - you must help them in kind, at all costs."
+	else
+		brainwash_message = "You feel at peace - a kinship in the fires of your heart feels a sympathy for [company] and their motives. \
+								With this newfound peace, you feel, deeply, that you should co-operate with members of their [department] department."
+	brainwash(target, brainwash_message)
+	message_admins("[ADMIN_LOOKUPFLW(user)] implanted [ADMIN_LOOKUPFLW(target)] with a compliance implant. Brainwashing Message: '[brainwash_message]'.")
+	qdel(src)
+
+/// Implant Case, along with the modification code.
+/obj/item/implantcase/compliance
+	name = "implant case - 'Compliance'"
+	desc = "A glass case containing a compliace implant. Use in-hand to customize to YOUR situation! \
+			Ethicality not guaranteed, please consult a licensed Psychiatrist before use."
+	imp_type = /obj/item/implant/compliance
+
+/obj/item/implantcase/compliance/attack_hand(mob/user, list/modifiers)
+	if(istype(imp, /obj/item/implant/compliance))
+		var/obj/item/implant/compliance/our_implant = imp
+		if(obj_flags & EMAGGED)
+			var/input = tgui_input_text(user, "What person do you wish to set this implant to be loyal to?", "Set Loyalty", "John Doe", MAX_NAME_LEN)
+			if(isnull(input))
+				return
+			our_implant.calibrated_person = input
+
+		else
+			var/input = tgui_input_text(user, "What corporation do you wish to set this implant to be loyal to? I.E. Nanotrasen, Interdyne Pharmaceuticals, Cybersun Industries...", "Set Corporation", "Nanotrasen", MAX_NAME_LEN)
+			if(isnull(input))
+				return
+			our_implant.company = input
+			input = tgui_input_text(user, "What department do you wish to set this implant to be compliant with? I.E. Security, Science, Medical", "Set Department", "Security", MAX_NAME_LEN)
+			if(isnull(input))
+				return
+			our_implant.department = input
+
+/obj/item/implantcase/compliance/emag_act()
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+

--- a/code/game/objects/items/implants/implant_compliance.dm
+++ b/code/game/objects/items/implants/implant_compliance.dm
@@ -12,21 +12,35 @@
 
 /obj/item/implant/compliance/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
-				<b>Name:</b> Compliance Implant<BR>
-				<b>Life:</b> Immediately self-destructs upon payload delivery.<BR>
-				"}
+				<b>Name:</b> S.P.E.C.T.R.A. - Compliance Implant<BR>
+				<b>Life:</b> 21 hours after death of host<BR>
+				<b>Implant Details:</b> <BR>
+				<b>Function:</b> Makes the implanted docile to a specific corporation and a department therein."}
 	return dat
 
 /obj/item/implant/compliance/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
-	. = ..()
+	for(var/X in target.implants)
+		if(istype(X, /obj/item/implant/compliance)) //Early check before we run the basic implant code.
+			return FALSE
+	. = ..() // We run the basetype implant code here, only to add onto it;
 	brainwash_message = "You feel at peace - a kinship in the fires of your heart feels a sympathy for [company] and their motives. \
 						With this newfound peace, you feel, deeply, that you should co-operate with members of their [department] department."
 	if(obj_flags & EMAGGED)
 		brainwash_message = "Whispers in the back of your skull make you feel uneasy, make you feel wrong. Yet, the whispers cease as [calibrated_person] \
 							is near, a light in the darkness. There's an incessant, nagging thankfulness in you as you think of them - you must help them in kind, at all costs."
-	brainwash(target, brainwash_message)
-	message_admins("[ADMIN_LOOKUPFLW(user)] implanted [ADMIN_LOOKUPFLW(target)] with a compliance implant. Brainwashing Message: '[brainwash_message]'.")
-	qdel(src)
+	handle_antag_addition(target, user)
+	message_admins("[ADMIN_LOOKUPFLW(user)] implanted [ADMIN_LOOKUPFLW(target)] with a compliance implant; Implanted Objective: '[brainwash_message]'.")
+
+/obj/item/implant/compliance/proc/handle_antag_addition(mob/living/target, mob/user)
+	var/datum/antagonist/compliance/our_antag_datum = new
+	our_antag_datum.forge_objectives(brainwash_message)
+	target.mind.add_antag_datum(our_antag_datum)
+
+/obj/item/implant/compliance/removed(mob/target, silent = FALSE, special = FALSE)
+	. = ..()
+	var/datum/mind/DystopianNovelProtagonist = target.mind
+	if(DystopianNovelProtagonist.has_antag_datum(/datum/antagonist/compliance)) // Sanity check
+		DystopianNovelProtagonist.remove_antag_datum(/datum/antagonist/compliance)
 
 /// Implant Case, along with the modification code.
 /obj/item/implantcase/compliance

--- a/code/game/objects/items/implants/implant_compliance.dm
+++ b/code/game/objects/items/implants/implant_compliance.dm
@@ -18,6 +18,7 @@
 	return dat
 
 /obj/item/implant/compliance/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
+	. = ..()
 	if(obj_flags & EMAGGED)
 		brainwash_message = "Whispers in the back of your skull make you feel uneasy, make you feel wrong. Yet, the whispers cease as [calibrated_person] \
 							is near, a light in the darkness. There's an incessant, nagging thankfulness in you as you think of them - you must help them in kind, at all costs."

--- a/code/game/objects/items/implants/implant_compliance.dm
+++ b/code/game/objects/items/implants/implant_compliance.dm
@@ -19,12 +19,11 @@
 
 /obj/item/implant/compliance/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	. = ..()
+	brainwash_message = "You feel at peace - a kinship in the fires of your heart feels a sympathy for [company] and their motives. \
+						With this newfound peace, you feel, deeply, that you should co-operate with members of their [department] department."
 	if(obj_flags & EMAGGED)
 		brainwash_message = "Whispers in the back of your skull make you feel uneasy, make you feel wrong. Yet, the whispers cease as [calibrated_person] \
 							is near, a light in the darkness. There's an incessant, nagging thankfulness in you as you think of them - you must help them in kind, at all costs."
-	else
-		brainwash_message = "You feel at peace - a kinship in the fires of your heart feels a sympathy for [company] and their motives. \
-								With this newfound peace, you feel, deeply, that you should co-operate with members of their [department] department."
 	brainwash(target, brainwash_message)
 	message_admins("[ADMIN_LOOKUPFLW(user)] implanted [ADMIN_LOOKUPFLW(target)] with a compliance implant. Brainwashing Message: '[brainwash_message]'.")
 	qdel(src)
@@ -55,8 +54,8 @@
 				return
 			our_implant.department = input
 
-/obj/item/implantcase/compliance/emag_act()
-	if(obj_flags & EMAGGED)
+/obj/item/implantcase/compliance/emag_act(user)
+	if(imp.obj_flags & EMAGGED)
 		return
-	obj_flags |= EMAGGED
-
+	imp.obj_flags |= EMAGGED
+	balloon_alert(user, "Card Swiped")

--- a/code/game/objects/items/implants/implant_compliance.dm
+++ b/code/game/objects/items/implants/implant_compliance.dm
@@ -35,7 +35,7 @@
 			Ethicality not guaranteed, please consult a licensed Psychiatrist before use."
 	imp_type = /obj/item/implant/compliance
 
-/obj/item/implantcase/compliance/attack_hand(mob/user, list/modifiers)
+/obj/item/implantcase/compliance/attack_self(mob/user, list/modifiers)
 	if(istype(imp, /obj/item/implant/compliance))
 		var/obj/item/implant/compliance/our_implant = imp
 		if(obj_flags & EMAGGED)

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -365,6 +365,7 @@
 			"Ghost and Other Roles" = list(
 				ROLE_PAI,
 				ROLE_BRAINWASHED,
+				ROLE_COMPLIANT,
 				ROLE_DEATHSQUAD,
 				ROLE_DRONE,
 				ROLE_LAVALAND,

--- a/code/modules/antagonists/compliance_implant/compliance_implant.dm
+++ b/code/modules/antagonists/compliance_implant/compliance_implant.dm
@@ -1,0 +1,18 @@
+/// This is an antag datum for the same reason ERTs and brainwashing and all that jazz is.
+/// Mostly a shell - see implant_compliance.dm for the rest.
+
+/datum/antagonist/compliance
+	name = "\improper Compliance Implanted"
+	job_rank = ROLE_COMPLIANT
+	roundend_category = "compliance implanted"
+	show_in_antagpanel = FALSE
+	antagpanel_category = "Other"
+	show_name_in_check_antagonists = TRUE
+	suicide_cry = "FOR... SOMEONE!!"
+
+/datum/antagonist/compliance/proc/forge_objectives(var/implant_text)
+	var/datum/objective/brainwashing/brainwash_objective = new /datum/objective/brainwashing
+	brainwash_objective.owner = owner
+	brainwash_objective.explanation_text = implant_text
+	objectives += brainwash_objective
+

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -599,6 +599,16 @@
 	category = list(RND_SUBCATEGORY_IMPLANTS)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
 
+/datum/design/implant_compliance
+	name = "Compliance Implant Case"
+	desc = "A glass case containing a compliance implant, used for easy-to-use co-operation from prisoners."
+	id = "implant_compliance"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/gold = 100)
+	build_path = /obj/item/implantcase/compliance
+	category = list(RND_SUBCATEGORY_IMPLANTS)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
 //Cybernetic organs
 
 /datum/design/cybernetic_liver

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1339,6 +1339,15 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
+/datum/techweb_node/interrogation_implants
+	id = "interrogation_implants"
+	display_name = "Interrogation Implants"
+	description = "Simplified compliance devices for those untrained for more advanced machines."
+	prereq_ids = list("subdermal_implants", "interrogation")
+	design_ids = list(
+		"implant_compliance"
+	)
+
 /datum/techweb_node/cyber_organs
 	id = "cyber_organs"
 	display_name = "Cybernetic Organs"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1339,15 +1339,6 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
-/datum/techweb_node/interrogation_implants
-	id = "interrogation_implants"
-	display_name = "Interrogation Implants"
-	description = "Simplified compliance devices for those untrained for more advanced machines."
-	prereq_ids = list("subdermal_implants", "interrogation")
-	design_ids = list(
-		"implant_compliance"
-	)
-
 /datum/techweb_node/cyber_organs
 	id = "cyber_organs"
 	display_name = "Cybernetic Organs"
@@ -1558,6 +1549,7 @@
 		"spkkit",
 		"G17kit",
 		"r84kit",
+		"implant_compliance"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1927,6 +1927,7 @@
 #include "code\game\objects\items\implants\implant_abductor.dm"
 #include "code\game\objects\items\implants\implant_chem.dm"
 #include "code\game\objects\items\implants\implant_clown.dm"
+#include "code\game\objects\items\implants\implant_compliance.dm"
 #include "code\game\objects\items\implants\implant_deathrattle.dm"
 #include "code\game\objects\items\implants\implant_exile.dm"
 #include "code\game\objects\items\implants\implant_explosive.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2415,6 +2415,7 @@
 #include "code\modules\antagonists\clown_ops\bananium_bomb.dm"
 #include "code\modules\antagonists\clown_ops\clown_weapons.dm"
 #include "code\modules\antagonists\clown_ops\outfits.dm"
+#include "code\modules\antagonists\compliance_implant\compliance_implant.dm"
 #include "code\modules\antagonists\creep\creep.dm"
 #include "code\modules\antagonists\cult\blood_magic.dm"
 #include "code\modules\antagonists\cult\cult.dm"


### PR DESCRIPTION
Adds the Compliance Implant as part of the Security Arsenal; A much-more limited use implant that, instead of implanting a trigger phrase into a subject to be used at whim ala the Enhanced Interrogation Chamber, injects them with a pre-configured phrase emploring them to assist a company and a specific department within it so long as the implant remains within them.

If the implant case is emagged, this goal changes towards helping a specific person instead. You *will* need to set the name to your own, or another's, or an alias, manually..

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Compliance Implants have been added, a dumbed-down, direct-application bit of customizable brainwashing to make sure prisoners stay in line. Consult the ethical review board for more information.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
