### PR TITLE
Disables Lathe Tax, Reverts Offstation Lathes to Omnilathes

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -89,7 +89,7 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "aA" = (
-/obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 9
 	},

--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -609,9 +609,9 @@
 /area/ruin/syndicate_lava_base/bar)
 "dT" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/rndboards{
-	pixel_y = 15;
-	pixel_x = 2
+/obj/item/storage/box/rndboards/mundane{
+	pixel_y = 13;
+	pixel_x = 5
 	},
 /obj/item/storage/part_replacer{
 	pixel_y = 6

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -3731,8 +3731,9 @@
 /area/ruin/syndicate_lava_base/medbay)
 "LK" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/rndboards{
-	pixel_y = 4
+/obj/item/storage/box/rndboards/mundane{
+	pixel_y = 13;
+	pixel_x = 5
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -3830,10 +3830,7 @@
 /area/ruin/space/ks13/engineering/singulo)
 "DK" = (
 /obj/structure/rack,
-/obj/item/circuitboard/machine/circuit_imprinter/offstation{
-	pixel_x = 6;
-	pixel_y = 6
-	},
+/obj/item/circuitboard/machine/circuit_imprinter,
 /obj/item/ai_module/core/full/drone,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/ai/corridor)
@@ -5316,7 +5313,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/circuitboard/machine/protolathe/offstation,
+/obj/item/circuitboard/machine/protolathe,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/ai/corridor)
 "LM" = (

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -9,7 +9,7 @@
 /area/ruin/space)
 "ac" = (
 /obj/machinery/porta_turret/syndicate/energy{
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 60, "energy" = 60, "bomb" = 60, "bio" = 0, "fire" = 100, "acid" = 100);
+	armor = list("melee"=40,"bullet"=40,"laser"=60,"energy"=60,"bomb"=60,"bio"=0,"fire"=100,"acid"=100);
 	dir = 4;
 	name = "Syndicate Ship Turret";
 	on = 0;
@@ -121,7 +121,7 @@
 "ay" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";
@@ -176,7 +176,6 @@
 	lethal = 1;
 	name = "Ship turret control panel";
 	pixel_y = 32;
-	req_access = null;
 	req_access = list("syndicate")
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -334,8 +333,6 @@
 /obj/structure/closet/crate/secure/gear{
 	req_access = list("syndicate")
 	},
-/obj/item/circuitboard/machine/circuit_imprinter/offstation,
-/obj/item/circuitboard/machine/protolathe/offstation,
 /obj/item/stack/sheet/iron/twenty,
 /obj/item/stack/sheet/glass{
 	amount = 10
@@ -345,6 +342,8 @@
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/beakers,
+/obj/item/circuitboard/machine/circuit_imprinter,
+/obj/item/circuitboard/machine/protolathe,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bg" = (
@@ -453,7 +452,7 @@
 "bw" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";
@@ -634,7 +633,7 @@
 "bY" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";
@@ -673,7 +672,7 @@
 "ce" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";
@@ -693,7 +692,7 @@
 "cg" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";
@@ -716,7 +715,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ci" = (
 /obj/machinery/porta_turret/syndicate/energy{
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 60, "energy" = 60, "bomb" = 60, "bio" = 0, "fire" = 100, "acid" = 100);
+	armor = list("melee"=40,"bullet"=40,"laser"=60,"energy"=60,"bomb"=60,"bio"=0,"fire"=100,"acid"=100);
 	dir = 4;
 	name = "Syndicate Ship Turret";
 	on = 0;
@@ -760,7 +759,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cp" = (
 /obj/machinery/door/window{
-	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 10, "bio" = 0, "fire" = 70, "acid" = 100);
+	armor = list("melee"=50,"bullet"=50,"laser"=50,"energy"=50,"bomb"=10,"bio"=0,"fire"=70,"acid"=100);
 	name = "Control Room";
 	req_access = list("syndicate")
 	},
@@ -1088,7 +1087,7 @@
 "df" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";
@@ -1105,7 +1104,7 @@
 "dg" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";
@@ -1146,7 +1145,7 @@
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/grunge{
-	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 50, "bio" = 0, "fire" = 90, "acid" = 90);
+	armor = list("melee"=50,"bullet"=50,"laser"=50,"energy"=50,"bomb"=50,"bio"=0,"fire"=90,"acid"=90);
 	desc = "Vault airlock preventing air from going out.";
 	name = "Syndicate Vault Airlock"
 	},
@@ -1210,7 +1209,7 @@
 "kY" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
-	armor = list("melee" = 70, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 30, "bio" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee"=70,"bullet"=40,"laser"=40,"energy"=30,"bomb"=30,"bio"=0,"fire"=70,"acid"=60);
 	desc = "A basic closet for all your villainous needs.";
 	locked = 1;
 	name = "Closet";

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -2045,8 +2045,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hydro)
 "gG" = (
-/obj/machinery/rnd/production/protolathe/offstation,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/rnd/production/protolathe,
 /turf/open/floor/iron/white,
 /area/ruin/space/ancientstation/delta/rnd)
 "gH" = (
@@ -2071,9 +2071,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/beta/mining)
 "gM" = (
-/obj/machinery/rnd/production/circuit_imprinter/offstation,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/dropper,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/white,
 /area/ruin/space/ancientstation/delta/rnd)
 "gO" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -2349,7 +2349,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/circuitboard/machine/protolathe/offstation,
 /obj/effect/spawner/random/engineering/toolbox,
-/obj/item/circuitboard/machine/circuit_imprinter/department/no_tax,
+/obj/item/circuitboard/machine/circuit_imprinter/department,
 /obj/item/circuitboard/machine/rtg/advanced,
 /obj/item/circuitboard/machine/rtg/advanced,
 /obj/item/circuitboard/machine/rtg/advanced,

--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -2347,13 +2347,13 @@
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/circuitboard/machine/protolathe/offstation,
 /obj/effect/spawner/random/engineering/toolbox,
-/obj/item/circuitboard/machine/circuit_imprinter/department,
 /obj/item/circuitboard/machine/rtg/advanced,
 /obj/item/circuitboard/machine/rtg/advanced,
 /obj/item/circuitboard/machine/rtg/advanced,
 /obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/protolathe,
+/obj/item/circuitboard/machine/circuit_imprinter,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/cargodise_freighter/utility)
 "LC" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -1,1178 +1,14851 @@
-"aa" = (/obj/effect/turf_decal/siding/dark,/obj/machinery/light/cold/directional/west,/obj/structure/closet/secure_closet{name = "prisoner item locker"; req_access = list("syndicate_leader")},/obj/machinery/power/apc/auto_name/directional/west{req_access = list("syndicate")},/obj/structure/cable,/obj/item/restraints/handcuffs,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ab" = (/obj/machinery/light/cold/directional/east,/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/effect/turf_decal/stripes/red/corner,/obj/structure/bed/dogbed,/mob/living/simple_animal/hostile/retaliate/tegu{name = "Entertains-The-Hostages"},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ac" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/closet/secure_closet{name = "MODsuit module locker"; req_access = list("syndicate_leader"); icon_state = "syndicate"},/obj/item/mod/module/stealth,/obj/item/mod/module/projectile_dampener{pixel_x = 8; pixel_y = 2},/obj/item/mod/module/pepper_shoulders,/obj/item/mod/module/criminalcapture{pixel_x = -3; pixel_y = -5},/obj/item/mod/module/visor/night,/obj/item/screwdriver/nuke{pixel_y = -2},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"ad" = (/obj/machinery/telecomms/relay/preset/mining,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"ae" = (/obj/effect/turf_decal/bot,/obj/effect/spawner/random/decoration/carpet,/obj/structure/closet/crate/cardboard,/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/effect/spawner/random/maintenance/three,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"af" = (/obj/effect/turf_decal/stripes/red/corner,/obj/structure/cable,/obj/structure/bed/dogbed,/mob/living/simple_animal/pet/cat/kitten{desc = "What appears to be a single-celled organism with a pronounced low-level intelligence."; name = "Murder-Mittens"},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"ag" = (/obj/effect/turf_decal/trimline/purple/warning{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/junction/flip{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"ah" = (/obj/structure/table,/obj/item/paper_bin,/obj/item/pen,/obj/effect/turf_decal/stripes/red/line,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"aj" = (/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/circuitboard/machine/mech_recharger,/obj/effect/turf_decal/trimline/dark_red/filled/line,/obj/effect/turf_decal/siding/dark{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"ak" = (/obj/effect/turf_decal/siding/wood,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/machinery/door/firedoor,/obj/machinery/door/airlock/command{hackProof = 1; id_tag = "scorpliaison"; name = "Corporate Liaison"},/obj/effect/mapping_helpers/airlock/locked,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/mapping_helpers/airlock/unres,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"ao" = (/obj/machinery/stasis,/obj/machinery/camera/xray/directional/south{network = list("ds2"); c_tag = "DS-2 Medical"},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 6},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"at" = (/obj/effect/turf_decal/siding/dark{dir = 6},/obj/structure/table/reinforced,/obj/machinery/reagentgrinder{desc = "Used to grind things up into raw materials and liquids."; pixel_y = 5},/obj/machinery/light/cold/directional/south,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"au" = (/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/effect/turf_decal/delivery/red,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/door/airlock/security/old/glass{name = "Security Checkpoint"},/obj/effect/mapping_helpers/airlock/unres,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"av" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 9},/obj/effect/turf_decal/siding/dark{dir = 9},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/obj/machinery/camera/xray/directional/north{network = list("ds2"); c_tag = "DS-2 Isolation Cell"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ax" = (/obj/machinery/conveyor{dir = 8; id = "ds2conveyor"},/obj/structure/railing,/obj/machinery/light/red/directional/north,/obj/structure/plasticflaps,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"az" = (/obj/effect/turf_decal/trimline/dark_blue/line{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"aB" = (/obj/machinery/vending/imported/tizirian,/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"aC" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"aF" = (/obj/effect/turf_decal/trimline/dark_blue/line{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/cold/directional/east,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"aH" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/structure/chair{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 9},/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"aJ" = (/obj/effect/turf_decal/vg_decals/numbers/one{dir = 4},/turf/open/floor/engine/hull,/area/template_noop)
-"aL" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 10},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/structure/cable,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"aN" = (/obj/machinery/atmospherics/components/binary/valve/digital,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"aP" = (/obj/machinery/door/firedoor,/obj/machinery/door/window/survival_pod{dir = 8; req_access = list("syndicate")},/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{dir = 4},/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{dir = 4},/obj/structure/table/reinforced/plastitaniumglass,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"aR" = (/obj/effect/turf_decal/trimline/dark_green/warning{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"aT" = (/turf/closed/wall/r_wall/syndicate,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"aW" = (/obj/machinery/porta_turret/syndicate/energy{dir = 6},/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"aX" = (/obj/effect/turf_decal/bot_white,/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{dir = 4},/obj/machinery/portable_atmospherics/scrubber,/obj/effect/turf_decal/siding/thinplating/dark{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"aY" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/table/reinforced,/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/recharger,/obj/item/paper_bin{pixel_x = -14},/obj/item/pen{pixel_x = -14},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"aZ" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{dir = 5},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"ba" = (/obj/effect/turf_decal/stripes/red/corner,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"bd" = (/obj/effect/turf_decal/siding/dark{dir = 9},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/machinery/firealarm/directional/west,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"be" = (/obj/structure/disposalpipe/segment{dir = 2},/obj/structure/lattice/catwalk,/obj/machinery/atmospherics/components/unary/outlet_injector/on{dir = 1; volume_rate = 200},/turf/template_noop,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"bj" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/chair/office,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"bk" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/button/door{id = "ds2armory"; req_access = list("syndicate_leader"); name = "Armory Access"; desc = "To keep your valuable gear away from prying eyes."; pixel_x = 32; pixel_y = 24},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"bn" = (/obj/structure/window/reinforced/tinted{dir = 1},/obj/structure/window/reinforced/tinted{dir = 8},/obj/machinery/power/shuttle_engine/heater,/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"bo" = (/obj/machinery/disposal/bin,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/disposalpipe/trunk{dir = 1},/obj/effect/turf_decal/siding/thinplating/end{dir = 8},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"bq" = (/obj/item/storage/belt/security/full,/obj/item/radio/headset/interdyne,/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,/obj/item/storage/belt/security/webbing/ds,/obj/item/clothing/head/beret/sec/syndicate,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/item/clothing/accessory/armband{name = "brig officer armband"; desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/closet/secure_closet{icon_state = "sec"; name = "brig officer gear locker"; req_access = list("syndicate_leader")},/obj/item/clothing/mask/gas/syndicate/ds,/obj/item/clothing/suit/toggle/jacket/sec/old{name = "brig officer jacket"},/obj/item/clothing/mask/gas/sechailer/syndicate,/obj/item/gun/energy/disabler,/obj/item/clothing/glasses/hud/security/sunglasses/eyepatch/redsec,/obj/item/clothing/glasses/hud/security/sunglasses/redsec,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"bs" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/effect/turf_decal/siding/dark/corner{dir = 4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"bt" = (/obj/structure/bed{dir = 1},/obj/item/bedsheet/syndie{name = "station admiral's bedsheet"; dir = 1},/turf/open/floor/carpet/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"bu" = (/obj/structure/curtain,/obj/structure/drain,/obj/machinery/shower/directional/north,/obj/effect/turf_decal/siding/dark{dir = 10},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"bw" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"bx" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 9},/obj/effect/turf_decal/siding/dark{dir = 9},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/button/curtain{id = "DS2cell2"; name = "curtain control"; pixel_y = 24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"by" = (/obj/machinery/vending/security{name = "\improper Stolen Armadyne Equipment Vendor"; desc = "An Armadyne peacekeeper equipment vendor. Makes you wonder why there's no Gorlex Equipment Vendor yet."},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"bA" = (/obj/machinery/door/firedoor,/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/effect/turf_decal/trimline/yellow/corner,/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"bP" = (/obj/structure/table,/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/item/storage/bag/tray/cafeteria,/obj/item/storage/bag/tray/cafeteria{pixel_y = 3},/obj/item/storage/bag/tray/cafeteria{pixel_y = 6},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"bR" = (/obj/machinery/computer/operating,/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"bS" = (/obj/item/melee/baton/telescopic{pixel_x = 4; pixel_y = 9},/obj/item/melee/baton/telescopic{pixel_x = 10; pixel_y = 9},/obj/item/melee/baton/telescopic{pixel_x = -2; pixel_y = 9},/obj/item/melee/energy/sword/saber/red,/obj/item/melee/energy/sword/saber/red{pixel_x = 13},/obj/item/melee/energy/sword/saber/red{pixel_x = 7},/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/structure/rack/shelf,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"bW" = (/obj/structure/cable,/obj/effect/turf_decal/tile/dark_red/half/contrasted,/obj/effect/turf_decal/siding/wideplating_new/dark,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/structure/disposalpipe/segment{dir = 6},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"bX" = (/obj/structure/table/reinforced,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/effect/turf_decal/trimline/purple/filled/line{dir = 9},/obj/item/paper,/obj/item/pen{pixel_y = 3; pixel_x = -5},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"bY" = (/obj/effect/turf_decal/trimline/purple/filled/line,/obj/effect/turf_decal/siding/dark/corner{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/firealarm/directional/south,/obj/structure/chair/office/light{dir = 8},/turf/open/floor/iron/dark/side,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"ca" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"cb" = (/obj/item/clothing/shoes/galoshes{pixel_y = -8},/obj/item/reagent_containers/spray/cleaner{pixel_x = 6; pixel_y = -6},/obj/item/holosign_creator/janibarrier{pixel_y = -9},/obj/item/mop,/obj/effect/turf_decal/tile/purple/half{dir = 4},/obj/machinery/light/small/directional/east,/obj/structure/mop_bucket/janitorialcart{dir = 4},/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"ch" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair{dir = 8},/obj/machinery/camera/xray/directional/north{network = list("ds2"); c_tag = "DS-2 Diner"},/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"cj" = (/obj/effect/turf_decal/skyrat_decals/syndicate/middle/middle,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/obj/effect/turf_decal/skyrat_decals/ds2/middle,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"cm" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/transit_tube{dir = 8},/obj/structure/cable,/obj/machinery/door/poddoor/preopen{id = "ds2bridge"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"cn" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"cq" = (/obj/effect/turf_decal/tile/yellow/half{dir = 1},/obj/machinery/light/cold/directional/east,/obj/effect/turf_decal/siding/wideplating_new/dark/corner,/obj/machinery/button/door/directional/east{desc = "To keep your hangar away from prying eyes."; id = "void-be-gone"; name = "Hangar Blast Door Control"; req_access = list("syndicate")},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/obj/structure/extinguisher_cabinet/directional/north,/obj/effect/turf_decal/tile/dark_red,/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 4},/turf/open/floor/iron/dark/textured_edge{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"cr" = (/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating/end{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/effect/turf_decal/siding/wideplating/dark{dir = 4},/obj/structure/disposalpipe/trunk,/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"ct" = (/obj/effect/turf_decal/bot_white,/obj/structure/table,/obj/effect/spawner/random/food_or_drink/donkpockets,/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"cu" = (/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/duct,/obj/machinery/door/airlock/freezer{name = "Medical Storage"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"cy" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"cz" = (/obj/effect/turf_decal/siding/dark/corner{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"cA" = (/obj/structure/railing,/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"cD" = (/obj/effect/turf_decal/siding/dark/corner,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"cE" = (/obj/effect/turf_decal/bot,/obj/machinery/fishing_portal_generator,/obj/item/storage/toolbox/fishing,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"cG" = (/obj/item/bedsheet/qm{name = "corporate liaison's bedsheet"; desc = "It is decorated with the Donk Co. logo."},/obj/structure/bed,/turf/open/floor/carpet/donk,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"cI" = (/obj/machinery/power/shuttle_engine/propulsion/left{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/light/floor{use_power = 0},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"cL" = (/obj/machinery/door/airlock/grunge{name = "Interrogation Room"},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"cO" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/machinery/power/apc/auto_name/directional/east{req_access = list("syndicate")},/obj/structure/cable,/obj/machinery/cell_charger_multi,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"cP" = (/obj/effect/turf_decal/trimline/blue/corner,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 9},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"cS" = (/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"cU" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"cW" = (/obj/item/gun/energy/recharge/kinetic_accelerator,/obj/item/storage/bag/ore,/obj/item/mining_scanner,/obj/structure/closet/secure_closet{icon_state = "mining"; req_access = list("syndicate"); name = "mining gear locker"},/obj/item/storage/belt/mining/alt,/obj/item/clothing/under/syndicate/skyrat/overalls{pixel_y = -2},/obj/item/storage/backpack/satchel/explorer,/obj/item/storage/backpack/explorer,/obj/item/clothing/accessory/armband/cargo{name = "mining officer armband"; desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"cY" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/duct,/turf/open/floor/iron/showroomfloor,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"da" = (/obj/effect/turf_decal/siding/wood{dir = 1},/obj/structure/hedge,/obj/machinery/light/warm/directional/north,/obj/structure/sign/painting/library{pixel_y = 30},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"dg" = (/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/east{req_access = list("syndicate")},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"dh" = (/obj/effect/turf_decal/siding/wood,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"dn" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"do" = (/obj/structure/extinguisher_cabinet/directional/west,/obj/effect/turf_decal/siding/wood{dir = 9},/obj/structure/table/wood/fancy/black,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"dr" = (/obj/structure/cable,/obj/machinery/light/cold/directional/west,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/circuitboard/machine/ore_redemption,/obj/item/assembly/igniter,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"ds" = (/obj/effect/turf_decal/arrows{dir = 8; pixel_x = 14},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"dv" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/curtain/cloth/fancy/mechanical{color = "#555555"; icon_state = "bathroom-open"; id = "DS2cell2"; icon_type = "bathroom"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"dy" = (/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{dir = 4},/turf/open/floor/engine/n2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"dz" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/yellow/warning,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/junction/yjunction,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"dC" = (/obj/structure/dresser,/obj/item/flashlight/lamp/green{pixel_x = 5; pixel_y = 15},/turf/open/floor/carpet/donk,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"dD" = (/obj/effect/turf_decal/siding/thinplating/dark,/obj/effect/turf_decal/trimline/dark_red/end,/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 4},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 8},/obj/structure/chair/office{dir = 1},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"dF" = (/obj/machinery/button/door/directional/north{desc = "Keep out the riff-raff."; id = "sadmiral"; name = "Admiral's room bolt"; normaldoorcontrol = 1; req_access = list("syndicate_leader"); specialfunctions = 4},/obj/effect/turf_decal/siding/wood,/obj/machinery/light/warm/directional/east,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/obj/structure/bed/dogbed,/obj/effect/decal/cleanable/oil,/mob/living/basic/pet/syndifox,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"dI" = (/obj/effect/turf_decal/bot_white,/obj/structure/sink/kitchen/directional/west,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"dN" = (/obj/effect/turf_decal/siding/yellow{dir = 8},/obj/effect/turf_decal/trimline/yellow/filled/line{dir = 4},/obj/effect/turf_decal/trimline/yellow/warning{dir = 8},/obj/effect/turf_decal/trimline/yellow/line{dir = 4},/obj/structure/closet/secure_closet/ds2atmos{anchorable = 0; anchored = 1},/turf/open/floor/iron/dark/side{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"dO" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/effect/turf_decal/trimline/dark_red/line{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/effect/turf_decal/trimline/dark_red/corner,/obj/effect/turf_decal/trimline/dark_red/corner{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"dQ" = (/obj/effect/turf_decal/siding/wood{dir = 1},/obj/machinery/door/airlock/command{hackProof = 1; id_tag = "sadmiral"; name = "Station Admiral"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/locked,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/machinery/door/firedoor,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/mapping_helpers/airlock/unres,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"dR" = (/obj/machinery/shower/directional/north,/obj/effect/turf_decal/siding/dark{dir = 6},/obj/structure/drain,/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"dS" = (/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{dir = 4},/obj/effect/turf_decal/bot_white,/obj/machinery/portable_atmospherics/scrubber,/obj/machinery/light/warm/directional/west,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"dT" = (/obj/machinery/power/shuttle_engine/propulsion/right{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 1},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"dZ" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"ee" = (/obj/item/reagent_containers/condiment/milk,/obj/item/reagent_containers/condiment/soymilk,/obj/item/storage/fancy/egg_box,/obj/effect/turf_decal/bot_blue,/obj/structure/closet/secure_closet/freezer/kitchen{req_access = list("syndicate")},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"ek" = (/obj/effect/turf_decal/siding/wood{dir = 1},/obj/structure/hedge,/obj/structure/sign/painting/library{pixel_y = 30},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"em" = (/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{dir = 10},/obj/machinery/meter,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"eo" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/structure/closet/secure_closet/personal{icon_state = "cabinet"},/obj/item/clothing/under/misc/syndicate_souvenir{has_sensor = 0; pixel_y = -4},/obj/item/clothing/under/misc/syndicate_souvenir{has_sensor = 0; pixel_y = -7; pixel_x = 4},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"ep" = (/obj/structure/closet/secure_closet/freezer/meat{req_access = list("syndicate")},/obj/effect/turf_decal/bot_blue,/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"ez" = (/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{dir = 5},/obj/effect/turf_decal/stripes/line{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 6},/obj/machinery/atmospherics/components/binary/valve/digital{dir = 4},/obj/machinery/button/door/directional/south{desc = "Keep out the Blazing heat."; id = "DS2incineratorHatch"; name = "Incinerator Hatch Bolt"; normaldoorcontrol = 1; req_access = list("syndicate_leader"); specialfunctions = 4; pixel_x = 6},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"eA" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/effect/turf_decal/siding/yellow{dir = 8},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"eD" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/structure/table/reinforced/plastitaniumglass,/obj/effect/turf_decal/trimline/dark_red/line,/obj/structure/sign/flag/syndicate/directional/south{pixel_x = 16},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/obj/item/toy/mecha/darkgygax{pixel_y = 16},/obj/item/toy/figure/syndie,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"eE" = (/obj/structure/filingcabinet,/obj/machinery/power/apc/auto_name/directional/north,/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"eF" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"eH" = (/obj/effect/turf_decal/box/red/corners{dir = 1},/obj/effect/turf_decal/stripes/red/corner,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"eJ" = (/obj/machinery/light/cold/directional/south,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"eK" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/obj/structure/table,/obj/item/stack/sheet/mineral/plastitanium,/obj/item/stack/sheet/plastitaniumglass,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"eO" = (/obj/machinery/hydroponics/constructable,/obj/machinery/camera/xray/directional/east{network = list("ds2"); c_tag = "DS-2 Botany"},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"eP" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 1},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"eT" = (/obj/structure/table,/obj/item/analyzer{pixel_y = 10},/obj/item/pipe_dispenser{pixel_x = -3},/obj/machinery/power/terminal{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 10},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"eU" = (/obj/machinery/light/warm/directional/east,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"eW" = (/obj/machinery/button/door{id = "TESRedguard"; name = "Dorm Bolt Control"; normaldoorcontrol = 1; pixel_x = 24; specialfunctions = 4; pixel_y = -24},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"eX" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/effect/turf_decal/siding/yellow{dir = 8},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"eY" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/structure/cable,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"fa" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"fc" = (/obj/effect/turf_decal/box/red/corners{dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"fd" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/mob/living/simple_animal/bot/medbot/stationary{radio_channel = "Syndicate"; faction = list("Syndicate"); maints_access_required = list("syndicate"); name = "Insurgent Care"},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"fe" = (/obj/machinery/griddle,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ff" = (/obj/structure/cable,/obj/effect/turf_decal/siding/dark,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"fh" = (/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 1},/obj/effect/turf_decal/siding/wideplating/dark{dir = 1},/obj/machinery/duct,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"fl" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"fo" = (/obj/structure/closet/emcloset,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 6},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"fw" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/structure/chair/office/light,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"fy" = (/obj/machinery/light/cold/directional/west,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/effect/turf_decal/siding/dark,/obj/structure/chair/stool/directional/north,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"fz" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"fA" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"fB" = (/obj/effect/turf_decal/trimline/purple/line{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"fE" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 8},/obj/effect/turf_decal/trimline/dark_red/line{dir = 4},/obj/effect/turf_decal/trimline/dark_red/line{dir = 8},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 8},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 4},/obj/structure/sign/flag/syndicate/directional/north,/obj/structure/showcase/cyborg{icon = 'icons/mob/silicon/robots.dmi'; icon_state = "synd_sec"; name = "syndicate cyborg showcase"; desc = "A stand with the empty body of a Cybersun cyborg bolted to it."; dir = 8; pixel_x = 6},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"fQ" = (/obj/effect/turf_decal/tile/purple/half{dir = 8},/obj/effect/turf_decal/tile/brown,/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark/textured_edge{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"fS" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_blue/line{dir = 1},/obj/machinery/power/apc/auto_name/directional/north,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"fW" = (/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"gb" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"gg" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/turf_decal/stripes/line,/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/structure/disposalpipe/segment{dir = 2},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/mapping_helpers/airlock/cyclelink_helper,/obj/machinery/door/airlock/external/glass{name = "External Access"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"gi" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/vg_decals/numbers/two,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"gj" = (/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/turf_decal/delivery/red,/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/security/old{hackProof = 1; name = "Long-Term Brig"},/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{cycle_id = "DS2permabrig"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"gk" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"gn" = (/turf/closed/wall/r_wall/syndicate,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"go" = (/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"gv" = (/obj/machinery/porta_turret/syndicate/energy{dir = 5},/turf/closed/wall/r_wall/syndicate,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"gw" = (/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/circuitboard/machine/component_printer,/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 5},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"gx" = (/obj/machinery/door/airlock/engineering{name = "Engineering"},/obj/structure/cable,/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"gy" = (/obj/structure/table/reinforced,/obj/item/storage/box/teargas{pixel_x = 3; pixel_y = 6},/obj/item/storage/box/handcuffs{pixel_y = 3},/obj/item/storage/box/flashbangs{pixel_x = -3},/obj/effect/turf_decal/siding/dark/corner{dir = 1},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"gA" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"gB" = (/obj/structure/chair/sofa/bench/right{dir = 1},/obj/structure/cable,/obj/machinery/airalarm/syndicate{pixel_y = -24},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"gF" = (/obj/machinery/door/airlock/security/old/glass{name = "Security"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/delivery/red,/obj/structure/cable,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{cycle_id = "DS2brig"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"gG" = (/obj/structure/cable,/obj/effect/turf_decal/tile/dark_red/half/contrasted{dir = 4},/obj/structure/disposalpipe/segment{dir = 10},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 4},/obj/machinery/camera/xray/directional/north{network = list("ds2"); c_tag = "DS-2 Hangar Airlock"},/obj/structure/sign/flag/syndicate/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"gK" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{dir = 8},/obj/machinery/light/cold/directional/east,/obj/machinery/firealarm/directional/east,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"gN" = (/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input{dir = 8; chamber_id = "syndicatelava_incinerator"},/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"gO" = (/obj/machinery/door/airlock/public/glass{name = "Diner"},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"gW" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"ha" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 5},/obj/effect/turf_decal/siding/dark{dir = 5},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/table,/obj/effect/spawner/random/entertainment/cigarette_pack,/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"he" = (/obj/effect/turf_decal/bot_blue,/obj/machinery/light/warm/directional/north,/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{dir = 4},/obj/machinery/portable_atmospherics/pump,/obj/effect/turf_decal/siding/thinplating/dark{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"hf" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_blue/corner{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/light/cold/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"hg" = (/obj/machinery/suit_storage_unit/syndicate/softsuit,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"hh" = (/obj/structure/chair/comfy/brown{color = "#596479"; dir = 1},/obj/machinery/firealarm/directional/south,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"hi" = (/obj/effect/turf_decal/siding/wood,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"hn" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"ho" = (/obj/machinery/computer/security{network = list("ds2"); dir = 4},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"hq" = (/obj/structure/drain,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating{dir = 6},/obj/structure/disposalpipe/trunk{dir = 4},/obj/machinery/firealarm/directional/north,/obj/machinery/duct,/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"hs" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"hx" = (/obj/machinery/power/turbine/inlet_compressor,/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"hy" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/effect/turf_decal/siding/dark/corner,/obj/effect/turf_decal/siding/dark/corner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"hz" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"hA" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/light/cold/directional/east,/obj/effect/spawner/random/contraband/prison,/obj/structure/closet/crate/bin,/obj/effect/spawner/random/trash/food_packaging{pixel_y = -5},/obj/effect/spawner/random/trash/cigbutt,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"hC" = (/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/siding/dark,/obj/structure/window/reinforced/survival_pod,/obj/structure/rack,/obj/item/storage/medkit/emergency,/obj/machinery/light/cold/directional/east,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"hE" = (/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/machinery/light/cold/directional/north,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"hF" = (/obj/item/tank/internals/plasmaman/belt{pixel_x = -6},/obj/item/tank/internals/plasmaman/belt{pixel_x = 3},/obj/item/tank/internals/nitrogen/belt{pixel_x = -6},/obj/item/tank/internals/nitrogen/belt,/obj/item/tank/internals/nitrogen/belt{pixel_x = 6},/obj/item/clothing/mask/breath,/obj/item/clothing/mask/breath,/obj/item/clothing/mask/breath,/obj/item/clothing/mask/breath,/obj/structure/rack/shelf,/obj/effect/turf_decal/trimline/blue/line{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"hG" = (/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"hH" = (/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"hJ" = (/obj/effect/turf_decal/siding/wood,/obj/structure/hedge,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/structure/extinguisher_cabinet/directional/south,/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"hM" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/door/poddoor/preopen{id = "void-be-gone"},/obj/structure/fans/tiny/forcefield{dir = 4},/turf/open/floor/engine/hull,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"hP" = (/obj/machinery/light/cold/directional/east,/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/machinery/vending/cigarette,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"hQ" = (/obj/effect/turf_decal/tile/yellow{dir = 1},/obj/effect/turf_decal/bot,/obj/structure/closet/crate/cardboard,/obj/item/pai_card,/obj/effect/spawner/random/maintenance/three,/turf/open/floor/iron/dark/textured_edge,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"hR" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"hT" = (/obj/effect/turf_decal/trimline/dark_blue/filled/line,/obj/effect/turf_decal/siding/dark,/obj/structure/extinguisher_cabinet/directional/west,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"hZ" = (/obj/structure/railing{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/stripes/end{dir = 1},/obj/effect/turf_decal/siding/dark/end{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"ib" = (/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white,/obj/machinery/chem_heater/withbuffer,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"ie" = (/obj/structure/bed,/obj/item/bedsheet/hos{name = "master at arms's bedsheet"},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/carpet/royalblack,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"ih" = (/obj/effect/turf_decal/trimline/brown/corner{dir = 1},/obj/structure/cable,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/obj/machinery/light/cold/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"ij" = (/obj/effect/turf_decal/trimline/purple/filled/corner{dir = 4},/obj/item/circuitboard/machine/circuit_imprinter/offstation,/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"il" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"io" = (/obj/machinery/door/firedoor,/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/door/window/survival_pod{dir = 8; req_access = list("syndicate")},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"it" = (/obj/structure/chair,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"iw" = (/obj/effect/turf_decal/bot,/obj/structure/closet/crate/freezer{name = "imported ingredient freezer"},/obj/item/reagent_containers/condiment/vinegar{pixel_x = -3; pixel_y = 11},/obj/item/reagent_containers/condiment/yoghurt{pixel_x = 6; pixel_y = 5},/obj/item/reagent_containers/condiment/cornmeal{pixel_x = -6; pixel_y = 2},/obj/item/food/canned_jellyfish{pixel_x = 5},/obj/item/food/desert_snails{pixel_y = 1; pixel_x = -3},/obj/item/food/canned/tomatoes,/obj/item/food/canned/tuna{pixel_y = -5; pixel_x = -6},/obj/item/food/canned/pine_nuts{pixel_y = -9; pixel_x = 10},/obj/item/reagent_containers/condiment/quality_oil{pixel_x = 3; pixel_y = -2},/obj/item/food/fishmeat/moonfish{pixel_y = -11},/obj/item/food/fishmeat/moonfish{pixel_y = -8},/obj/item/food/fishmeat/moonfish{pixel_y = -5},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"ix" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/trimline/purple/filled/line,/obj/machinery/light/cold/directional/south,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/item/storage/box/stockparts/basic{pixel_y = 6},/obj/item/storage/box/stockparts/basic{pixel_x = 8},/obj/item/storage/box/beakers{pixel_x = -4; pixel_y = -2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"iy" = (/obj/effect/turf_decal/trimline/dark_blue/corner{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"iz" = (/obj/effect/turf_decal/stripes/red/corner{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"iB" = (/obj/machinery/light/cold/directional/west,/obj/machinery/atmospherics/miner/oxygen,/turf/open/floor/engine/o2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"iE" = (/obj/structure/lattice,/obj/structure/transit_tube{dir = 8},/turf/template_noop,/area/template_noop)
-"iF" = (/obj/effect/turf_decal/trimline/dark_blue/filled/line,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"iK" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/grunge{id_tag = "TESArena"; name = "Dormitory"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"iM" = (/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"iO" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"iP" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/biogenerator,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"iR" = (/obj/structure/dresser,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"iS" = (/obj/machinery/atmospherics/pipe/smart/manifold/green/hidden{dir = 8},/obj/machinery/meter,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"iV" = (/obj/item/chair{dir = 8; pixel_x = 5; pixel_y = -3},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"iX" = (/obj/structure/chair/office/light{dir = 8},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"iY" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair{dir = 4},/obj/structure/extinguisher_cabinet/directional/north,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"iZ" = (/obj/machinery/light/warm/directional/south,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"jb" = (/obj/machinery/iv_drip,/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"jc" = (/obj/effect/turf_decal/trimline/dark_blue/line{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"jd" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/item/bodybag/environmental/prisoner/syndicate{pixel_x = -7; pixel_y = 15},/obj/item/bodybag/environmental/prisoner/syndicate{pixel_x = 7; pixel_y = 15},/obj/item/bodybag/environmental/prisoner/syndicate{pixel_y = 8},/obj/structure/table/reinforced,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/machinery/power/apc/auto_name/directional/west{req_access = list("syndicate")},/obj/structure/cable,/obj/machinery/camera/xray/directional/west{network = list("ds2"); c_tag = "DS-2 Brig Storage"},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"jf" = (/obj/structure/closet/emcloset,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 10},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"jj" = (/obj/machinery/griddle,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"jl" = (/obj/effect/turf_decal/trimline/purple/filled/end{dir = 1},/obj/structure/table,/obj/machinery/coffeemaker,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"jm" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"jp" = (/obj/machinery/light/warm/directional/north,/obj/machinery/computer{name = "syndicate access change console"; icon_keyboard = "syndie_key"; icon_screen = "explosive"; desc = "A console meant to allow modifications to IDs. There's a chameleon ID stuck inside and no one has been able to pull it out..."},/obj/item/paper{default_raw_text = "<h1>DS2 Corporate Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>The Sothran Syndicate welcomes you onboard, Corporate Liaison. It is deeply suggested you help our crew via informing them of their corporate investors' goal and to help maintain cohesion. Don't hurt yourself now, and stay winning.</p>"; name = "paper- 'DS2 Corporate Report'"},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"jr" = (/obj/item/sign/flag/syndicate{pixel_y = 6; pixel_x = 3},/obj/item/flashlight/lamp/green{pixel_x = -6; pixel_y = 4},/obj/structure/table/wood/fancy/black,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/carpet/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"jt" = (/obj/effect/turf_decal/siding/wood,/obj/structure/hedge,/obj/structure/window/reinforced/survival_pod,/obj/machinery/light/warm/directional/south,/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"jw" = (/obj/machinery/door/firedoor,/obj/structure/disposalpipe/segment{dir = 2},/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"jB" = (/obj/structure/chair/comfy/brown{color = "#596479"},/obj/machinery/button/door{id = "ds2admiral"; req_access = list("syndicate_leader"); name = "Shutters control"; desc = "Keep out the paperwork."; pixel_y = 24; pixel_x = 32},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"jC" = (/obj/effect/turf_decal/skyrat_decals/syndicate/middle/right,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/skyrat_decals/ds2/right,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"jD" = (/obj/item/storage/secure/briefcase/white{pixel_y = 13},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"jE" = (/obj/effect/turf_decal/stripes/line{dir = 9},/obj/effect/turf_decal/siding/white{dir = 9},/obj/item/toy/figure/syndie{pixel_y = 20; pixel_x = 10},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"jJ" = (/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/circuitboard/machine/mechfab,/obj/effect/turf_decal/trimline/dark_red/filled/line,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"jN" = (/obj/effect/turf_decal/siding/wideplating_new/dark,/obj/effect/turf_decal/stripes/red/line{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"jO" = (/obj/effect/turf_decal/delivery/red,/obj/machinery/door/firedoor,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/stripes/red/line{dir = 1},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"jP" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/obj/structure/window/reinforced/survival_pod{dir = 5},/obj/structure/railing/corner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"jR" = (/obj/effect/turf_decal/box/red/corners,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"jT" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"jW" = (/obj/structure/closet/secure_closet{icon_state = "science"; name = "roboticist gear locker"; req_access = list("syndicate")},/obj/item/clothing/suit/hooded/techpriest,/obj/item/clothing/suit/hooded/wintercoat/robotics,/obj/item/clothing/suit/toggle/labcoat/roboticist{pixel_y = 3},/obj/item/clothing/under/syndicate/skyrat/overalls/skirt,/obj/item/clothing/under/syndicate/skyrat/overalls{pixel_y = -2},/obj/item/clothing/glasses/hud/ar/aviator/diagnostic,/obj/item/clothing/glasses/hud/diagnostic,/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"jZ" = (/obj/machinery/hydroponics/constructable,/obj/effect/turf_decal/bot_white,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ka" = (/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{dir = 1},/obj/effect/turf_decal/siding/thinplating/dark{dir = 8},/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"kb" = (/obj/structure/chair,/obj/effect/turf_decal/siding/wood{dir = 4},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"kc" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/junction/yjunction{dir = 8},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"kd" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/computer/turbine_computer{dir = 1; mapping_id = "syndicatelava_turbine"},/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 10},/obj/machinery/button/door/incinerator_vent_syndicatelava_aux{pixel_y = -6; pixel_x = -24; name = "Combustion Chamber Blast Door Control"},/obj/machinery/button/door/incinerator_vent_syndicatelava_main{pixel_x = -24; pixel_y = 6; name = "Turbine Exterior Vent Control"},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/button/ignition/incinerator/syndicatelava{pixel_x = -36},/obj/structure/cable,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"ke" = (/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"kf" = (/obj/effect/turf_decal/stripes/red/line,/obj/structure/disposalpipe/segment{dir = 5},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"kg" = (/obj/structure/transit_tube/crossing/horizontal,/obj/structure/lattice,/turf/template_noop,/area/template_noop)
-"km" = (/obj/machinery/button/door{id = "TESBattlespire"; name = "Dorm Bolt Control"; normaldoorcontrol = 1; pixel_x = -24; specialfunctions = 4; pixel_y = 24},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"kt" = (/obj/effect/turf_decal/stripes/end{dir = 1},/obj/structure/disposaloutlet,/obj/structure/disposalpipe/trunk{dir = 1},/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"kx" = (/obj/structure/lattice,/turf/template_noop,/area/template_noop)
-"kD" = (/obj/machinery/smartfridge/food,/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"kF" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"kG" = (/obj/structure/table/reinforced/plastitaniumglass,/obj/item/reagent_containers/condiment/peppermill{pixel_x = 6; pixel_y = 4},/obj/item/reagent_containers/condiment/saltshaker{pixel_y = 2},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"kH" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 1},/obj/effect/turf_decal/siding/wideplating/dark{dir = 1},/obj/machinery/vending/medical/syndicate_access/cybersun{desc = "An advanced vendor that dispenses medical drugs, both recreational and medicinal. It's said to have been salvaged from an old decomissioned Cybersun Cruiser."; name = "\improper SyndiMed ++"},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"kI" = (/obj/effect/turf_decal/siding/dark/end{dir = 4},/obj/machinery/light/cold/directional/east,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"kM" = (/obj/effect/turf_decal/siding/dark/corner{dir = 8},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"kN" = (/obj/machinery/door/firedoor,/obj/structure/table/reinforced,/obj/machinery/door/window/survival_pod{dir = 4; req_access = list("syndicate_leader")},/obj/machinery/door/window/survival_pod{dir = 8; heat_proof = 1},/obj/machinery/door/poddoor/shutters{name = "Corporate Liaison Shutters"; id = "ds2corpliaison"; dir = 8},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"kQ" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"kT" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/obj/structure/railing{dir = 4},/obj/machinery/light/warm/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"kZ" = (/obj/effect/turf_decal/trimline/brown/warning{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/disposalpipe/segment{dir = 5},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"lb" = (/obj/structure/table,/obj/machinery/microwave{pixel_y = 8},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ld" = (/obj/effect/turf_decal/bot,/obj/effect/spawner/random/maintenance/two,/obj/structure/closet/crate,/obj/effect/spawner/random/engineering/tool,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"lg" = (/obj/item/card/id/advanced/chameleon/black,/obj/item/card/id/advanced/chameleon/black,/obj/item/card/id/advanced/chameleon/black,/obj/structure/closet/secure_closet{icon_state = "hop"; name = "\proper corporate liaison's locker"; req_access = list("syndicate_leader")},/obj/effect/turf_decal/siding/wood{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/item/language_manual/codespeak_manual/unlimited,/obj/item/clothing/under/syndicate/skyrat/baseball,/obj/item/clothing/under/rank/captain/skyrat/utility/syndicate,/obj/item/clothing/under/suit/skyrat/helltaker{has_sensor = 0; random_sensor = 0},/obj/item/clothing/neck/chaplain/black{desc = "An unique cloak that shimmers with the Corporate Liaison's emblem."; name = "corporate liaison's cloak"},/obj/item/binoculars,/obj/item/radio/headset/interdyne/command,/obj/item/clothing/head/hos/beret/syndicate,/obj/item/clothing/glasses/sunglasses,/obj/item/encryptionkey/headset_syndicate/interdyne,/obj/item/encryptionkey/headset_syndicate/interdyne,/obj/item/encryptionkey/headset_syndicate/interdyne,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"li" = (/obj/structure/table/glass,/obj/item/storage/pill_bottle/mannitol{pixel_y = 6; pixel_x = -8},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 1},/obj/effect/turf_decal/siding/wideplating/dark{dir = 1},/obj/machinery/duct,/obj/item/stack/medical/gauze{pixel_x = 1; pixel_y = 4},/obj/item/stack/medical/mesh{pixel_x = 4},/obj/item/stack/medical/suture,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"lo" = (/obj/machinery/button/door{id = "syndie_ds2_vault"; name = "Vault Bolt Control"; normaldoorcontrol = 1; pixel_x = -24; pixel_y = 24; req_access = list("syndicate"); specialfunctions = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"lp" = (/obj/effect/turf_decal/siding/dark{dir = 6},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"lt" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/siding/dark{dir = 4},/obj/item/wirecutters,/obj/machinery/syndicatebomb/training,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"lu" = (/obj/machinery/light/cold/directional/north,/obj/machinery/firealarm/directional/north,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"lD" = (/obj/effect/turf_decal/siding/thinplating/dark,/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/line{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/structure/chair/office{dir = 1},/obj/structure/cable,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"lE" = (/obj/structure/closet/secure_closet/freezer/kitchen{req_access = list("syndicate")},/obj/item/reagent_containers/condiment/milk,/obj/item/reagent_containers/condiment/soymilk,/obj/item/storage/fancy/egg_box,/obj/effect/turf_decal/bot_blue,/obj/machinery/light/cold/directional/south,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"lF" = (/obj/effect/turf_decal/tile/dark_red/fourcorners,/obj/structure/table,/obj/item/mmi/posibrain{pixel_y = 6; pixel_x = 2},/obj/item/mmi/posibrain{pixel_x = -4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"lI" = (/obj/effect/turf_decal/stripes/line{dir = 10},/obj/machinery/light/red/directional/south,/obj/effect/turf_decal/siding/white{dir = 10},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"lJ" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/light/cold/directional/west,/obj/item/clothing/shoes/sneakers/crimson{pixel_x = -4},/obj/item/clothing/shoes/sneakers/crimson{pixel_x = 4},/obj/machinery/firealarm/directional/west,/obj/item/clothing/under/rank/prisoner/syndicate,/obj/item/clothing/under/rank/prisoner/syndicate{pixel_y = 4},/obj/item/clothing/under/rank/prisoner/syndicate{pixel_y = 8},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"lO" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"lU" = (/obj/effect/turf_decal/trimline/dark_blue/corner{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"lW" = (/obj/machinery/stasis,/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 5},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"lY" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"lZ" = (/obj/effect/turf_decal/siding/dark{dir = 9},/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/circuitboard/machine/smes,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"md" = (/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/obj/machinery/door/airlock/cmo/glass{name = "Medical Bay"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"me" = (/obj/machinery/button/door{id = "TESSkyrim"; name = "Restroom Bolt Control"; normaldoorcontrol = 1; pixel_x = -24; specialfunctions = 4; pixel_y = -24},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"mg" = (/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/siding/dark,/obj/structure/extinguisher_cabinet/directional/south,/obj/machinery/atmospherics/components/trinary/mixer/flipped{dir = 8; name = "plasma mixer"; target_pressure = 2000},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"mi" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/vending/hydroseeds,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"mj" = (/obj/machinery/photocopier,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"ml" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/fans/tiny,/obj/structure/cable,/obj/machinery/door/airlock/external/glass{name = "External Access"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"mr" = (/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/effect/turf_decal/siding/dark/corner{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"ms" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"mx" = (/obj/effect/turf_decal/trimline/dark_blue/line{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"my" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"mA" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"mC" = (/obj/structure/cable,/obj/machinery/power/smes/engineering{input_level = 150000; charge = 4.5e+006},/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/item/aicard/aitater{pixel_y = 11; pixel_x = 3},/obj/effect/turf_decal/siding/dark{dir = 5},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"mD" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/effect/turf_decal/tile/brown/half{dir = 8},/obj/effect/turf_decal/tile/purple{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/iron/dark/textured_edge{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"mH" = (/obj/machinery/door/firedoor,/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/door/window/survival_pod{req_access = list("syndicate_leader"); dir = 4},/obj/effect/turf_decal/delivery/red,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/item/folder/red,/obj/item/paper{pixel_y = -4; pixel_x = -3},/obj/item/paper{pixel_y = -6; pixel_x = 4},/obj/item/pen{pixel_y = -4},/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"mJ" = (/obj/effect/turf_decal/tile/brown,/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"mK" = (/obj/structure/table/wood,/obj/structure/window/reinforced/survival_pod,/obj/item/storage/bag/books,/obj/item/storage/book/bible/syndicate{pixel_x = -13},/obj/item/storage/fancy/candle_box{pixel_x = 4},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"mO" = (/obj/effect/turf_decal/trimline/blue/corner{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 5},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"mP" = (/obj/machinery/biogenerator,/obj/item/reagent_containers/cup/beaker/large,/obj/effect/turf_decal/bot_white,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"mQ" = (/obj/effect/turf_decal/box/red/corners{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"mT" = (/obj/effect/turf_decal/siding/dark,/obj/structure/table/glass,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"mX" = (/turf/closed/wall/r_wall/syndicate,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"mY" = (/obj/effect/turf_decal/siding/thinplating/dark,/obj/machinery/computer/station_alert{dir = 8},/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/line{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"nd" = (/obj/effect/turf_decal/trimline/blue/line{dir = 4},/turf/open/floor/iron/dark/textured_edge{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"ni" = (/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/machinery/light/cold/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/obj/structure/extinguisher_cabinet/directional/west,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"nm" = (/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"nn" = (/obj/machinery/firealarm/directional/west,/obj/effect/turf_decal/siding/wood{dir = 8},/obj/structure/chair/comfy/brown{color = "#596479"; dir = 1},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"ny" = (/obj/machinery/light/warm/directional/south,/turf/open/floor/carpet/blue,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"nz" = (/obj/structure/closet/crate/freezer/blood,/obj/machinery/duct,/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/turf/open/floor/iron/showroomfloor,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"nA" = (/obj/structure/cable,/obj/machinery/power/terminal{dir = 1},/obj/structure/table,/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/effect/turf_decal/siding/dark{dir = 6},/obj/item/storage/box/stockparts/basic{pixel_y = 11; pixel_x = -3},/obj/item/storage/box/stockparts/basic{pixel_y = 8; pixel_x = 5},/obj/item/storage/box/stockparts/basic,/obj/item/storage/part_replacer{pixel_y = -12; pixel_x = -2},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"nG" = (/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/effect/turf_decal/siding/dark,/obj/structure/rack/shelf,/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_researcher{pixel_y = -6},/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_digger{pixel_y = -3},/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_recoverer,/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_scanner{pixel_y = 3},/obj/structure/extinguisher_cabinet/directional/east,/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"nH" = (/obj/effect/turf_decal/siding/wood{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 6},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"nI" = (/obj/effect/turf_decal/siding/wood,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"nK" = (/obj/effect/turf_decal/bot,/obj/machinery/computer/monitor{dir = 4},/obj/structure/cable,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"nL" = (/obj/machinery/light/warm/directional/west,/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden,/obj/machinery/meter,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"nN" = (/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{dir = 4},/obj/machinery/meter,/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/space_heater,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"nO" = (/obj/machinery/porta_turret/syndicate/energy{dir = 9},/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"nR" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/stationmed{dir = 8},/turf/open/floor/iron/showroomfloor,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"nS" = (/obj/effect/turf_decal/bot_white,/obj/structure/easel,/obj/item/canvas/twentythree_nineteen,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"nT" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"ob" = (/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/structure/table,/obj/item/knife{pixel_x = -9; pixel_y = 3},/obj/item/kitchen/rollingpin,/obj/item/reagent_containers/condiment/saltshaker{pixel_y = -4},/obj/item/reagent_containers/condiment/peppermill{pixel_x = 6},/obj/structure/cable,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 6},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"oc" = (/obj/machinery/chem_master,/obj/machinery/light/cold/directional/south,/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white{dir = 1},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"od" = (/obj/machinery/atmospherics/components/unary/portables_connector/visible,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"of" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/line{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/machinery/light/cold/directional/south,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"og" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/segment,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"oi" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"ok" = (/obj/machinery/door/airlock/public/glass{name = "Dormitories"},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"on" = (/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"oq" = (/obj/effect/turf_decal/tile/brown/half,/obj/effect/turf_decal/trimline/blue/corner{dir = 1},/obj/structure/tank_dispenser/oxygen,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"or" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/item/sign/flag/syndicate{pixel_y = 6; pixel_x = -3},/obj/structure/table/glass,/obj/item/reagent_containers/cup/glass/waterbottle{pixel_x = 8; pixel_y = 4},/obj/structure/cable,/turf/open/floor/carpet/royalblack,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"ot" = (/obj/machinery/light/cold/directional/east,/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/stationmed{dir = 8},/turf/open/floor/iron/showroomfloor,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"ou" = (/obj/effect/turf_decal/trimline/dark_red/corner,/obj/effect/turf_decal/trimline/dark_red/corner{dir = 8},/obj/machinery/computer{name = "syndicate communications console"; icon_keyboard = "tech_key"; icon_screen = "comm"; desc = "A console meant to communicate with Syndicate upper command. This one seems to be busy processing flight calculations since you last saw it..."},/obj/item/paper{default_raw_text = "<h1>DS2 Transfer Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>Active syndicate operatives have been transferred over to the target NT workplace and are NOT to be interacted with under any circumstances, unless Syndicate Command allows it. Permission to monitor their activities is granted and heavily suggested.</p><p>Stay winning.</p>"; name = "paper- 'DS2 Transfer Report'"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"ov" = (/obj/structure/disposalpipe/segment{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"ow" = (/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/obj/structure/closet/secure_closet/medical1{req_access = list("syndicate")},/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"oz" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"oC" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"oE" = (/obj/effect/turf_decal/tile/blue,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"oG" = (/obj/machinery/porta_turret/syndicate{dir = 5; faction = list("Syndicate","neutral")},/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"oK" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"oO" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/structure/disposalpipe/segment,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"oR" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/light/cold/directional/east,/obj/structure/rack/shelf,/obj/item/crowbar/power/syndicate{pixel_y = 8},/obj/item/crowbar/power/syndicate{pixel_y = 2},/obj/item/crowbar/power/syndicate{pixel_y = -4},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"oS" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{dir = 8},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"oT" = (/obj/machinery/icecream_vat,/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"oV" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/bathroom{id_tag = "TESSkyrim"; name = "Restroom"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"oZ" = (/obj/machinery/vending/games,/obj/machinery/camera/xray/directional/west{network = list("ds2"); c_tag = "DS-2 Lounge"},/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"pa" = (/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/effect/turf_decal/trimline/brown/corner,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"pb" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/conveyor{id = "ds2disposals"},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/spawner/random/trash/garbage{pixel_y = -10},/turf/open/floor/iron/pool,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"pe" = (/obj/machinery/light/cold/directional/north,/obj/effect/turf_decal/trimline/dark_red/filled,/obj/effect/turf_decal/siding/white/corner,/obj/effect/turf_decal/siding/white/corner{dir = 4},/obj/effect/turf_decal/siding/white/corner{dir = 8},/obj/effect/turf_decal/siding/white/corner{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"pf" = (/obj/structure/sign/poster/contraband/icebox_moment{pixel_y = -32},/obj/effect/turf_decal/stripes/red/corner,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 5},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"pi" = (/obj/machinery/computer/crew/syndie{dir = 4},/obj/effect/turf_decal/siding/dark,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"pk" = (/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/circuitboard/machine/module_duplicator,/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"pl" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/item/circuitboard/computer/rdconsole,/obj/structure/frame/computer{dir = 8},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"pn" = (/obj/effect/turf_decal/skyrat_decals/departments/bridge{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark/textured_edge{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"pr" = (/obj/machinery/door/poddoor/incinerator_syndicatelava_main{name = "Turbine Exterior Vent"},/obj/effect/turf_decal/stripes/line,/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"ps" = (/obj/machinery/computer/cryopod/interdyne{dir = 4; pixel_x = -24},/obj/structure/table,/obj/effect/turf_decal/trimline/dark_green/filled/line{dir = 8},/obj/effect/turf_decal/trimline/dark_green/filled/line{dir = 4},/obj/effect/turf_decal/siding/thinplating/dark{dir = 4},/turf/open/floor/iron/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"pt" = (/obj/machinery/light/warm/directional/north,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"pu" = (/obj/effect/turf_decal/siding/dark/corner,/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"py" = (/obj/structure/marker_beacon/burgundy,/obj/effect/turf_decal/tile/dark_red/half,/obj/effect/turf_decal/siding/wideplating_new/dark,/obj/machinery/camera/xray/directional/north{network = list("ds2"); c_tag = "DS-2 Hangar North"},/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"pz" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair/stool/bar{dir = 4},/obj/effect/turf_decal/siding/wood{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"pB" = (/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/turf_decal/delivery/red,/obj/machinery/door/airlock/security/old/glass{name = "Long-Term Brig"},/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/machinery/door/firedoor,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{cycle_id = "DS2permabrig"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"pI" = (/obj/effect/turf_decal/siding/wood,/obj/structure/window/reinforced/survival_pod,/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating/end{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/structure/disposalpipe/trunk{dir = 8},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"pL" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/item/storage/box/firingpins/syndicate{pixel_y = 6; pixel_x = -2},/obj/item/storage/box/firingpins/syndicate{pixel_x = 2},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"pO" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"pP" = (/obj/machinery/door/firedoor,/obj/structure/table/reinforced/plastitaniumglass,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/item/paper_bin{pixel_y = 4},/obj/effect/turf_decal/delivery/red,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/stripes/red/line{dir = 4},/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"pW" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{dir = 8},/obj/structure/window/reinforced/survival_pod,/obj/effect/turf_decal/siding/dark,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"pX" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/curtain/cloth/fancy/mechanical{color = "#555555"; icon_state = "bathroom-open"; id = "DS2cell1"; icon_type = "bathroom"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"qa" = (/obj/structure/table,/obj/item/book/manual/wiki/cooking_to_serve_man,/obj/item/storage/box/donkpockets/donkpocketpizza{pixel_x = 5; pixel_y = 6},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"qc" = (/obj/structure/bed/double{dir = 1},/obj/item/bedsheet/brown/double{dir = 1},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"qh" = (/obj/structure/window/reinforced/tinted,/obj/machinery/power/shuttle_engine/heater{dir = 1},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"qj" = (/obj/structure/dresser,/obj/item/flashlight/lamp/green{pixel_x = 5; pixel_y = 15},/turf/open/floor/carpet/royalblack,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"qn" = (/obj/machinery/light/no_nightlight/directional/east,/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"qo" = (/obj/structure/rack/shelf,/obj/item/mod/module/chameleon{pixel_x = 6},/obj/item/mod/module/chameleon{pixel_y = -6; pixel_x = -2},/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 9},/obj/effect/spawner/random/mod{pixel_x = 6; pixel_y = -8},/obj/effect/spawner/random/mod,/obj/item/mod/construction/broken_core{pixel_x = -6; pixel_y = 6},/obj/item/mod/core/standard,/obj/item/mod/construction/broken_core{pixel_x = -2; pixel_y = -6},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"qs" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/item/storage/wallet/random,/obj/item/clothing/under/costume/jabroni{has_sensor = 0; random_sensor = 0},/obj/structure/closet/secure_closet/personal{icon_state = "cabinet"},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"qt" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/brown/warning,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"qu" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/railing/corner,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"qv" = (/obj/machinery/door/firedoor,/obj/effect/turf_decal/trimline/dark_green/line{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"qw" = (/obj/machinery/suit_storage_unit/syndicate/chameleon{name = "suit storage unit"; req_access = list("syndicate_leader")},/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"qz" = (/obj/machinery/power/shuttle_engine/propulsion/left{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 1},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"qC" = (/obj/machinery/door/airlock/service/glass{name = "Hydroponics"},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"qE" = (/obj/structure/rack,/obj/item/clothing/shoes/magboots/syndie{pixel_y = 8},/obj/item/clothing/shoes/magboots/syndie,/obj/effect/turf_decal/tile/blue,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/west{req_access = list("syndicate")},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"qH" = (/obj/structure/table,/obj/machinery/light/cold/directional/east,/obj/item/rsf{pixel_y = 14},/obj/item/rcd_ammo{pixel_y = 11},/obj/item/plate,/obj/item/plate{pixel_y = 2},/obj/item/plate{pixel_y = 4},/obj/structure/extinguisher_cabinet/directional/east,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"qI" = (/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/machinery/computer/crew/syndie,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"qK" = (/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"qN" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/carpet/royalblack,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"qO" = (/obj/machinery/conveyor_switch/oneway{id = "ds2conveyor"},/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"qR" = (/obj/machinery/vending/imported/mothic,/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"qS" = (/obj/effect/turf_decal/siding/wood{dir = 10},/obj/structure/disposalpipe/segment{dir = 1},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"qW" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/structure/chair/office/light{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"qY" = (/obj/structure/table,/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/south{req_access = list("syndicate")},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/obj/item/radio{desc = "An old handheld radio. You could use it, if you really wanted to."; icon_state = "radio"; name = "old radio"; pixel_y = 5},/obj/effect/turf_decal/tile/neutral{dir = 8},/obj/effect/turf_decal/trimline/dark/corner{dir = 8},/obj/effect/turf_decal/trimline/dark/corner{dir = 8},/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"ra" = (/obj/effect/turf_decal/delivery/white,/obj/machinery/door/airlock/bathroom{name = "Brig Restroom"},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"rb" = (/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{dir = 4},/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 8},/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 4},/obj/effect/turf_decal/trimline/dark_red/filled/mid_joiner{dir = 4},/obj/effect/turf_decal/trimline/dark_red/filled/mid_joiner{dir = 8},/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/siding/dark,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"rc" = (/obj/effect/turf_decal/delivery/red,/obj/effect/mob_spawn/ghost_role/human/ds2/prisoner{dir = 4},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"rd" = (/obj/effect/turf_decal/arrows{dir = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"rg" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue,/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"ri" = (/obj/effect/turf_decal/siding/wood{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"rj" = (/obj/item/kirbyplants{icon_state = "plant-22"},/obj/effect/turf_decal/siding/wood{dir = 5},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"rk" = (/obj/effect/turf_decal/trimline/purple/corner{dir = 4},/obj/effect/turf_decal/trimline/brown/warning,/obj/structure/disposalpipe/junction/yjunction{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"rl" = (/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"ro" = (/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 1},/obj/machinery/door/airlock/silver/glass{name = "Kitchen"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"rr" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"rs" = (/obj/machinery/shower/directional/north,/obj/effect/turf_decal/siding/dark{dir = 10},/obj/structure/drain,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"rx" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/trimline/purple/filled/line{dir = 6},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"rz" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/stripes/red/line,/obj/structure/cable,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"rB" = (/obj/effect/turf_decal/tile/purple,/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"rD" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/firealarm/directional/east,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"rG" = (/obj/machinery/door/airlock/engineering{name = "Ship Atmospherics"},/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{dir = 8},/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{dir = 4},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"rH" = (/obj/machinery/light/cold/directional/west,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/structure/bookcase/random{books_to_load = 10},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"rI" = (/obj/structure/reagent_dispensers/water_cooler,/obj/effect/turf_decal/tile/neutral{dir = 1},/obj/effect/turf_decal/trimline/dark/corner{dir = 1},/obj/effect/turf_decal/trimline/dark/corner{dir = 1},/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"rM" = (/obj/structure/table,/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/effect/spawner/random/food_or_drink/condiment{pixel_y = 6; pixel_x = 8},/obj/structure/cable,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"rN" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/fans/tiny,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/obj/machinery/door/airlock/external/glass{name = "External Access"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"rU" = (/obj/machinery/dryer{pixel_y = 20; pixel_x = 8},/obj/structure/sink/directional/east{pixel_y = -6},/obj/structure/mirror/directional/west,/obj/effect/turf_decal/siding/dark{dir = 9},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"rY" = (/obj/structure/rack,/obj/item/restraints/handcuffs,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"rZ" = (/obj/effect/turf_decal/siding/dark/corner,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"sa" = (/obj/effect/turf_decal/skyrat_decals/syndicate/bottom/left,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"sc" = (/obj/structure/table/wood,/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"sh" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 10},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"sj" = (/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark/corner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"sl" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/camera/xray/directional/south{network = list("ds2"); c_tag = "DS-2 Long-Term Brig Access"},/obj/item/card/id/advanced/prisoner/ds2,/obj/item/card/id/advanced/prisoner/ds2{pixel_y = 4; trim = /datum/id_trim/syndicom/skyrat/ds2/prisoner},/obj/item/card/id/advanced/prisoner/ds2{pixel_y = 8; trim = /datum/id_trim/syndicom/skyrat/ds2/prisoner},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"sr" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"ss" = (/obj/effect/turf_decal/vg_decals/numbers/four{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 1},/turf/open/floor/engine/hull,/area/template_noop)
-"st" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"sy" = (/obj/effect/turf_decal/skyrat_decals/syndicate/middle/left,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/skyrat_decals/ds2/left,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"sB" = (/obj/effect/turf_decal/siding/wood{dir = 4},/obj/machinery/power/apc/auto_name/directional/east,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"sD" = (/obj/machinery/vending/sustenance,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"sH" = (/obj/effect/turf_decal/siding/wood{dir = 8},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"sK" = (/obj/effect/turf_decal/tile/dark_blue/fourcorners,/turf/open/floor/circuit/off,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"sL" = (/obj/structure/reagent_dispensers/water_cooler,/obj/machinery/firealarm/directional/south,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"sM" = (/obj/effect/turf_decal/siding/thinplating/dark/corner{dir = 4},/obj/effect/turf_decal/trimline/dark_red/line{dir = 10},/obj/effect/turf_decal/trimline/dark_red/corner{dir = 4},/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 8},/obj/structure/showcase/cyborg{icon = 'icons/mob/silicon/robots.dmi'; icon_state = "synd_sec"; name = "syndicate cyborg showcase"; desc = "A stand with the empty body of a Cybersun cyborg bolted to it."; dir = 4; pixel_x = -6},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron/dark/smooth_corner{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"sO" = (/obj/structure/table,/obj/effect/spawner/random/food_or_drink/refreshing_beverage{pixel_x = -7; pixel_y = 8},/obj/effect/spawner/random/food_or_drink/donkpockets_single{pixel_x = -4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"sP" = (/obj/effect/turf_decal/trimline/purple/filled/end,/obj/structure/table,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"sV" = (/obj/item/storage/box/beakers/bluespace{pixel_y = 8; pixel_x = -2},/obj/item/storage/box/beakers/bluespace{pixel_x = 2},/obj/structure/table/reinforced/plastitaniumglass,/obj/item/storage/bag/chemistry{pixel_x = -16},/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"sW" = (/obj/effect/turf_decal/trimline/blue/warning{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"sZ" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/vending/dinnerware{onstation = 0},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"tf" = (/obj/effect/turf_decal/siding/dark,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"tg" = (/obj/machinery/shower/directional/south,/obj/item/soap/syndie,/obj/effect/turf_decal/siding/dark{dir = 9},/obj/structure/drain,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"tk" = (/obj/effect/turf_decal/trimline/yellow/line,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/disposalpipe/junction{dir = 8},/obj/machinery/firealarm/directional/south,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"tl" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/structure/plasticflaps,/obj/machinery/conveyor{id = "ds2disposals"},/turf/open/floor/iron/pool,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"tm" = (/obj/machinery/vending/assist,/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/turf/open/floor/iron/dark/side{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"tn" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"tq" = (/obj/effect/turf_decal/trimline/yellow/line,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"tt" = (/obj/structure/bed/double,/obj/item/bedsheet/brown/double,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"tA" = (/obj/machinery/atmospherics/components/unary/thermomachine/freezer{dir = 1},/obj/item/paper{default_raw_text = "<h1>Gorlex Engineering</h1><p>New to setting up a turbine, operative? This neat little guide and set-up should teach you how, step by step.</p><p>The first step is setting up the burn chamber. The Air alarm is unlocked for syndicate access, and a single scrubber in the area is inactive. That is our burn chamber's scrubber. Set it to scoop up any gas you don't want in it - anything but plasma and oxygen - and set it on expanded reach.</p><p>Next is setting up the Plasma Mixer. A good ratio is somewhere between 30-70 and 40-60 Plasma and Oxygen, respectively. Don't forget to max out the mixer's pressure, else it'll only dribble in the gas!</p><p>Once that is done, make sure to activate the two digital valves on the floor. One will allow O2 to be brought to the mixer, and the other one will lead the gas mix directly into the chamber.</p><p>With the burn being ready, two last things are needed. First, you'll need to set up the ship's scrubbers system to actively pump into space the excess gasses (Water vapour, Co2) the burn will produce. If you want, you can select a gas to filter out, but that isn't necessary. Once everything is set up, flick the igniter switch on, turn on the turbine at the terminal, and watch that fire shine bright!</p>"; name = "paper- 'Gorlex Engineering Division - Turbine Easy-Set Guide'"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"tC" = (/obj/machinery/door/airlock/research{name = "Robotics"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"tD" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/machinery/camera/xray/directional/west{network = list("ds2"); c_tag = "DS-2 Security Checkpoint"},/obj/machinery/computer/crew/syndie{dir = 1},/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"tE" = (/obj/effect/turf_decal/stripes/line{dir = 5},/obj/effect/turf_decal/siding/white{dir = 5},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"tG" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"tL" = (/obj/structure/table/reinforced,/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/item/storage/medkit/advanced{pixel_y = 8; pixel_x = -2},/obj/item/storage/medkit/regular{pixel_y = 1; pixel_x = 3},/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white{dir = 8},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"tN" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden,/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"tP" = (/obj/machinery/door/airlock/security/old{hackProof = 1; name = "Armory"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/turf_decal/delivery/red,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/obj/effect/mapping_helpers/airlock/unres,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"tQ" = (/obj/effect/turf_decal/stripes/red/line,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"tR" = (/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"tS" = (/obj/structure/closet/crate/hydroponics,/obj/item/paper/guides/jobs/hydroponics,/obj/item/seeds/onion,/obj/item/seeds/garlic,/obj/item/seeds/potato,/obj/item/seeds/tomato,/obj/item/seeds/carrot,/obj/item/seeds/grass,/obj/item/seeds/ambrosia,/obj/item/seeds/wheat,/obj/item/seeds/pumpkin,/obj/effect/spawner/random/contraband/prison,/obj/item/seeds/tower,/obj/structure/window/reinforced/survival_pod,/obj/effect/turf_decal/siding/dark,/obj/machinery/light/cold/directional/west,/obj/item/seeds/tobacco,/obj/item/reagent_containers/cup/watering_can,/obj/item/cultivator,/obj/item/plant_analyzer,/obj/item/secateurs,/obj/item/shovel/spade,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"tT" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 10},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"tU" = (/obj/machinery/door/airlock/medical{name = "Chemistry"},/obj/effect/turf_decal/stripes/blue/line{dir = 4},/obj/effect/turf_decal/stripes/blue/line{dir = 8},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/mapping_helpers/airlock/cutaiwire,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"tY" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/shutters/preopen{dir = 4; id = "ds2detective"; name = "Interrogation Room Shutters"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"tZ" = (/obj/machinery/smartfridge/food,/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"ub" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/structure/disposalpipe/segment,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"uc" = (/obj/structure/chair/stool/directional/east,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ue" = (/obj/effect/turf_decal/tile/dark_blue{dir = 1},/obj/effect/turf_decal/tile/dark_blue,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/structure/closet/crate/goldcrate,/obj/machinery/power/apc/auto_name/directional/south{req_access = list("syndicate")},/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"uf" = (/obj/effect/turf_decal/siding/dark{dir = 5},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"uh" = (/obj/machinery/seed_extractor,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"ui" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/grunge{id_tag = "TESBattlespire"; name = "Dormitory"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"um" = (/obj/structure/reagent_dispensers/plumbed,/obj/effect/turf_decal/siding/thinplating{dir = 10},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"uo" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"uq" = (/obj/machinery/power/shuttle_engine/large,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"uu" = (/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"uA" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"uB" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/carpet/donk,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"uD" = (/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"uE" = (/obj/effect/turf_decal/tile/dark_blue,/obj/effect/turf_decal/tile/dark_blue{dir = 1},/obj/effect/turf_decal/siding/dark/corner,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/structure/safe,/obj/item/storage/box/syndie_kit/chameleon/ghostcafe{desc = "A sleek, sturdy box."; name = "Chameleon Kit"},/obj/item/reagent_containers/heroinbrick{name = "Tiger Coop stimulant brick"; desc = "A brick of stimulants meant for use by Tiger Cooperative agents. It seems this one's just a brittle block of heroin."},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"uL" = (/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/effect/turf_decal/siding/dark/corner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"uN" = (/obj/machinery/hydroponics/constructable,/obj/effect/turf_decal/bot_white,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"uS" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/delivery/red,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/door/firedoor,/obj/machinery/door/airlock/grunge{name = "Cell 1"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"uV" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"uW" = (/obj/structure/tank_holder/anesthetic,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"va" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/cable,/obj/machinery/door/poddoor/preopen{id = "ds2bridge"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"vc" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"vd" = (/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/circuitboard/machine/cyborgrecharger,/obj/effect/turf_decal/siding/dark{dir = 8},/obj/effect/turf_decal/trimline/dark_red/filled/line,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"ve" = (/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"vg" = (/obj/structure/table/optable,/obj/machinery/defibrillator_mount/loaded{pixel_y = 28},/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"vl" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"vo" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/structure/rack/shelf,/obj/item/stock_parts/cell/lead{pixel_x = 4; pixel_y = -6},/obj/item/stock_parts/cell/lead,/obj/item/stock_parts/cell/lead{pixel_x = -4; pixel_y = -8},/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"vp" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"vq" = (/obj/effect/turf_decal/tile/blue,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/effect/turf_decal/siding/dark/corner,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"vr" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/masteratarms,/turf/open/floor/carpet/royalblack,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"vv" = (/obj/effect/turf_decal/siding/wood{dir = 4},/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/south{req_access = list("syndicate")},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"vx" = (/obj/structure/closet/secure_closet{icon_state = "cap"; name = "\proper station admiral's locker"; req_access = list("syndicate")},/obj/item/clothing/head/hats/hos/syndicate,/obj/item/clothing/head/hos/beret/syndicate,/obj/item/clothing/suit/armor/vest/capcarapace/syndicate,/obj/item/clothing/under/rank/captain/skyrat/utility/syndicate,/obj/item/radio/headset/interdyne/command,/obj/item/clothing/suit/armor/vest/capcarapace/syndicate/winter,/obj/effect/turf_decal/siding/wood{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/item/clothing/glasses/sunglasses,/obj/item/ammo_box/magazine/m9mm_aps,/obj/item/clothing/accessory/medal/gold{name = "medal of admiralty"; desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of an Admiral to the Sothran Syndicate, and their undisputable authority over their crew."},/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"vA" = (/obj/machinery/quantumpad{map_pad_id = "ds2"; map_pad_link_id = "interdyne"; name = "quantum pad to Interdyne"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"vB" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"vD" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"vE" = (/obj/effect/turf_decal/trimline/yellow/line,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/airalarm/syndicate{pixel_y = -24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"vF" = (/obj/structure/curtain,/obj/structure/drain,/obj/machinery/shower/directional/north,/obj/effect/turf_decal/siding/dark{dir = 6},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"vK" = (/obj/structure/table/reinforced,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/obj/item/paper{default_raw_text = "<h1>DS2 Long-Term Brig Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>The Sothran Syndicate has been capable of kidnapping a few key NT workers of various hierarchy levels. It is your task to interrogate, question and break their wills in order to find more intel on our enemy, Nanotrasen.</p><p>Stay winning."; name = "paper- 'DS2 Long-Term Brig Report'"},/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"vM" = (/obj/effect/turf_decal/trimline/yellow/corner,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"vO" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/chair/office/light{dir = 8},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"vQ" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/firealarm/directional/west,/obj/machinery/door/firedoor,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"vR" = (/obj/machinery/disposal/delivery_chute{dir = 1},/obj/structure/disposalpipe/trunk{dir = 8},/obj/effect/turf_decal/stripes/full,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/conveyor{id = "ds2disposals"},/turf/open/floor/iron/pool,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"vS" = (/obj/machinery/porta_turret/syndicate/energy,/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"vT" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/vending/toyliberationstation,/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"vU" = (/turf/open/floor/engine/plasma,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"wc" = (/obj/structure/bed/maint,/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 6},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"we" = (/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"wg" = (/turf/template_noop,/area/template_noop)
-"wh" = (/obj/effect/turf_decal/siding/wood,/obj/structure/hedge,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 10},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"wj" = (/obj/machinery/vending/wardrobe/sec_wardrobe/red,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"wk" = (/obj/structure/table/reinforced,/obj/item/storage/toolbox/electrical{pixel_y = 8},/obj/item/storage/toolbox/syndicate,/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"wm" = (/obj/effect/turf_decal/siding/dark/corner,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/dark/corner{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"wn" = (/obj/effect/turf_decal/trimline/purple/filled/line,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/light/cold/directional/south,/turf/open/floor/iron/dark/side,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"wp" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/firealarm/directional/east,/obj/machinery/door/firedoor,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"wt" = (/obj/effect/turf_decal/box/red/corners{dir = 4},/obj/effect/turf_decal/stripes/red/corner{dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"wu" = (/obj/effect/turf_decal/skyrat_decals/syndicate/bottom/middle,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"wz" = (/obj/machinery/light/warm/directional/west,/obj/machinery/computer/security{network = list("ds2"); dir = 4},/obj/structure/sign/flag/syndicate/directional/west,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"wE" = (/obj/effect/turf_decal/stripes/red/line,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/dark/corner,/obj/effect/turf_decal/siding/dark/corner{dir = 8},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"wH" = (/obj/machinery/door/firedoor,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"wJ" = (/obj/effect/turf_decal/skyrat_decals/syndicate/top/middle,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"wN" = (/obj/structure/cable,/turf/open/floor/carpet/royalblack,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"wS" = (/obj/machinery/igniter/incinerator_syndicatelava,/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"wV" = (/obj/machinery/processor,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"xb" = (/obj/effect/turf_decal/trimline/blue/corner{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/bot,/obj/structure/ore_box,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"xc" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"xd" = (/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/siding/white,/obj/item/toy/figure/syndie{pixel_x = 10; pixel_y = -3},/obj/machinery/camera/xray/directional/south{network = list("ds2"); c_tag = "DS-2 Hangar South"},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"xk" = (/obj/machinery/chem_dispenser/drinks/fullupgrade{dir = 8; pixel_y = 0},/obj/structure/table/wood,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"xp" = (/obj/effect/turf_decal/stripes/red/line,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"xr" = (/turf/closed/wall/r_wall/syndicate,/area/ruin/space/has_grav/skyrat/interdynefob)
-"xu" = (/obj/effect/turf_decal/stripes/red/line,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"xx" = (/obj/structure/window/reinforced/survival_pod,/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/siding/dark,/obj/machinery/light/cold/directional/west,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"xy" = (/obj/machinery/light/warm/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"xB" = (/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{dir = 1},/obj/machinery/meter,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"xG" = (/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/door/window/survival_pod{dir = 4},/obj/effect/turf_decal/siding/thinplating/dark{dir = 4},/obj/machinery/door/firedoor,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"xH" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/wood{dir = 5},/obj/structure/cable,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"xQ" = (/obj/effect/turf_decal/stripes/red/full,/obj/effect/turf_decal/box/white,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"xS" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"xX" = (/obj/structure/chair/office{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"xZ" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 10},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/machinery/light/small/directional/south,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"ya" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/cmo/glass{name = "Medical Bay"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"yd" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/shutters{name = "Master At Arms Shutters"; id = "smasteratarms"},/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"ye" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 1},/obj/effect/turf_decal/siding/wideplating/dark{dir = 1},/obj/machinery/vending/drugs{name = "\improper SyndiDrug Plus"; onstation = 0},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"yh" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/light/cold/directional/west,/obj/structure/table,/obj/item/coin/iron{pixel_x = -10},/obj/item/toy/cards/deck,/obj/item/storage/dice{pixel_x = 8; pixel_y = 3},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"yi" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_blue/line{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/light/cold/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"yn" = (/obj/structure/disposalpipe/segment,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"yu" = (/obj/machinery/door/firedoor,/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_blue/line{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"yv" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"yy" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair{dir = 1},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"yH" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 5},/obj/effect/turf_decal/siding/dark{dir = 5},/obj/structure/bed/pod,/obj/item/bedsheet/black,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"yI" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 10},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"yL" = (/obj/effect/turf_decal/siding/dark,/obj/structure/closet/secure_closet{name = "prisoner item locker"; req_access = list("syndicate_leader")},/obj/item/restraints/handcuffs,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"yP" = (/obj/structure/chair,/obj/machinery/firealarm/directional/west,/obj/machinery/camera/directional/west{network = list("ds2"); c_tag = "DS-2 Dormitories"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"yR" = (/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"yS" = (/obj/effect/turf_decal/siding/thinplating/dark/corner{dir = 1},/obj/effect/turf_decal/trimline/dark_red/line{dir = 6},/obj/effect/turf_decal/trimline/dark_red/corner{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 4},/obj/structure/showcase/cyborg{icon = 'icons/mob/silicon/robots.dmi'; icon_state = "synd_sec"; name = "syndicate cyborg showcase"; desc = "A stand with the empty body of a Cybersun cyborg bolted to it."; dir = 8; pixel_x = 6},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron/dark/smooth_corner{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"yU" = (/obj/machinery/duct,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"yX" = (/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 1},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"zb" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"zc" = (/obj/structure/marker_beacon/burgundy,/obj/effect/turf_decal/tile/dark_red/half,/obj/effect/turf_decal/siding/wideplating_new/dark,/obj/machinery/light/red/directional/north,/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"zd" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 6},/obj/structure/cable,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"ze" = (/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/structure/disposalpipe/segment{dir = 2},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/fans/tiny,/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 1},/obj/machinery/door/airlock/external/glass{name = "External Access"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"zg" = (/obj/item/circuitboard/machine/protolathe/offstation,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"zh" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/hatch{name = "Janitorial Supplies"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/unres{dir = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"zl" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"zn" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/light/cold/directional/west,/obj/machinery/recharger,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"zp" = (/obj/effect/turf_decal/stripes/red/line,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"zq" = (/obj/structure/cable,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/structure/disposalpipe/segment{dir = 1},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"zt" = (/obj/structure/table/glass,/obj/item/clothing/neck/stethoscope{pixel_x = 12; pixel_y = 4},/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"zv" = (/obj/effect/turf_decal/vg_decals/numbers/zero{dir = 4},/obj/effect/turf_decal/stripes/line,/turf/open/floor/engine/hull,/area/template_noop)
-"zx" = (/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/layer_manifold/green/visible,/obj/machinery/meter,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"zy" = (/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{dir = 9},/obj/machinery/light/warm/directional/east,/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 5},/obj/effect/turf_decal/siding/dark{dir = 5},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"zA" = (/obj/effect/turf_decal/trimline/blue/line{dir = 8},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/turf/open/floor/iron/dark/textured_edge{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"zD" = (/obj/structure/table/wood,/obj/item/paper_bin/carbon{pixel_y = 3; pixel_x = -5},/obj/item/pen{pixel_y = 3; pixel_x = -5},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"zH" = (/turf/open/floor/carpet/donk,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"zI" = (/obj/machinery/power/shuttle_engine/large{dir = 1},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"zK" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"zL" = (/obj/effect/turf_decal/bot_blue,/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{dir = 4},/obj/machinery/portable_atmospherics/pump,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"zM" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/effect/turf_decal/siding/yellow{dir = 4},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"zN" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"zS" = (/obj/effect/turf_decal/trimline/purple/line{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"zU" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 5},/obj/machinery/light/cold/directional/west,/obj/structure/chair/office/light,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"zV" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"zX" = (/obj/structure/window/reinforced/tinted{dir = 1},/obj/machinery/power/shuttle_engine/heater,/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"Aa" = (/obj/effect/turf_decal/tile/dark_red/fourcorners,/obj/structure/table,/obj/machinery/ecto_sniffer,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Ae" = (/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/turf_decal/delivery/red,/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/door/airlock/security/old{hackProof = 1; name = "Long-Term Brig"},/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{cycle_id = "DS2permabrig"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Af" = (/obj/effect/turf_decal/trimline/blue/line{dir = 8},/turf/open/floor/iron/dark/textured_edge{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Al" = (/obj/structure/table,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"An" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/obj/machinery/door/airlock/external/glass{name = "External Access"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Ao" = (/obj/structure/sink/directional/east{pixel_x = -11},/obj/effect/turf_decal/siding/thinplating{dir = 5},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Ar" = (/obj/machinery/smartfridge/food,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"At" = (/obj/structure/dresser,/obj/item/flashlight/lamp/green{pixel_x = -4; pixel_y = 15},/turf/open/floor/carpet/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"Au" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/extinguisher_cabinet/directional/east,/obj/machinery/light/cold/directional/east,/obj/effect/turf_decal/tile/dark_red/half{dir = 4},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 4},/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Av" = (/obj/machinery/computer/atmos_alert,/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/structure/cable,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Aw" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Ax" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Ay" = (/turf/closed/wall/r_wall/syndicate,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Az" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/item/clothing/under/syndicate/skyrat/baseball,/obj/structure/closet/secure_closet/personal{icon_state = "cabinet"},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"AC" = (/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating/end{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/disposalpipe/trunk{dir = 1},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"AG" = (/obj/item/ammo_box/c9mm{pixel_x = -2},/obj/item/ammo_box/c9mm{pixel_x = 3; pixel_y = -3},/obj/item/ammo_box/magazine/m9mm{pixel_x = 3; pixel_y = -3},/obj/item/ammo_box/magazine/m9mm,/obj/item/ammo_box/magazine/m9mm{pixel_x = -3; pixel_y = 3},/obj/item/ammo_box/magazine/m9mm{pixel_x = -6; pixel_y = 6},/obj/item/ammo_box/advanced/s12gauge{pixel_x = 9; pixel_y = -10},/obj/item/ammo_box/advanced/s12gauge{pixel_x = 9; pixel_y = -5},/obj/item/ammo_box/advanced/s12gauge/rubber{pixel_y = -10; pixel_x = -9},/obj/item/ammo_box/advanced/s12gauge/rubber{pixel_y = -5; pixel_x = -9},/obj/structure/closet/secure_closet{icon_state = "riot"; name = "armory munitions locker"; req_access = list("syndicate_leader"); icon = 'modular_skyrat/master_files/icons/obj/closet.dmi'; anchored = 1},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"AI" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/trimline/dark_blue/warning{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"AK" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"AR" = (/obj/machinery/light/red/directional/south,/obj/machinery/airalarm/syndicate{pixel_y = -24},/obj/structure/marker_beacon/burgundy,/obj/effect/turf_decal/tile/dark_red/half{dir = 1},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 1},/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"AV" = (/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"AW" = (/obj/machinery/light/warm/directional/south,/obj/machinery/button/door/directional/south{desc = "Keep out the Truth."; id = "ds2detective"; name = "Interrogation Room shutters control"; req_access = list("syndicate")},/obj/item/kirbyplants{icon_state = "plant-21"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"AX" = (/obj/item/reagent_containers/cup/glass/waterbottle{pixel_x = 11},/obj/item/reagent_containers/cup/glass/waterbottle{pixel_x = 7; pixel_y = -4},/obj/effect/turf_decal/tile/neutral/half/contrasted,/obj/effect/turf_decal/trimline/dark/line,/obj/effect/turf_decal/trimline/dark/line,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"AZ" = (/obj/machinery/vending/boozeomat/syndicate_access,/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Bb" = (/obj/effect/turf_decal/vg_decals/atmos/oxygen{dir = 4},/turf/open/floor/engine/o2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Be" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 2},/obj/machinery/light/cold/directional/east,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Bi" = (/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/light/red/directional/north,/obj/item/circuitboard/machine/spaceship_navigation_beacon,/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"Bj" = (/obj/structure/table,/obj/machinery/reagentgrinder{pixel_y = 6},/obj/structure/sign/poster/contraband/kss13{pixel_x = 32},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Bk" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Bm" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/conveyor{id = "ds2disposals"},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/stripes/end,/obj/effect/spawner/random/trash/food_packaging,/obj/effect/spawner/random/trash/cigbutt{pixel_y = -10},/turf/open/floor/iron/pool,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Bs" = (/obj/structure/lattice,/obj/structure/transit_tube{dir = 8},/obj/machinery/camera/xray/directional/north{network = list("ds2"); c_tag = "DS-2 Transit Tube"},/turf/template_noop,/area/template_noop)
-"Bt" = (/obj/structure/sink/kitchen/directional/west,/obj/structure/sign/poster/contraband/moffuchis_pizza{pixel_x = 32},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Bu" = (/obj/machinery/suit_storage_unit/syndicate/chameleon{name = "suit storage unit"; req_access = list("syndicate_leader")},/obj/machinery/power/apc/auto_name/directional/east{req_access = list("syndicate")},/obj/structure/cable,/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Bv" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/structure/rack/shelf,/obj/item/shovel{pixel_y = 2},/obj/item/pickaxe{pixel_y = -4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Bw" = (/obj/structure/railing{dir = 4},/obj/machinery/conveyor_switch{id = "ds2fakelevator"; pixel_y = 12; desc = "An elevator control switch. This one seems defunct."; name = "elevator control"},/obj/structure/railing/corner{pixel_y = 32},/obj/effect/turf_decal/tile/dark_red/half{dir = 1},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 1},/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"By" = (/obj/machinery/door/firedoor,/obj/structure/disposalpipe/segment{dir = 2},/obj/machinery/door/airlock/cmo/glass{name = "Medical Bay"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"BC" = (/obj/machinery/light/cold/directional/north,/obj/machinery/chem_master/condimaster{name = "BrewMaster 3000"},/obj/structure/cable,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"BG" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/miner,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"BL" = (/obj/structure/table,/obj/item/book/manual/chef_recipes,/obj/item/reagent_containers/condiment/enzyme,/obj/item/reagent_containers/condiment/saltshaker{pixel_x = -8; pixel_y = 5},/obj/item/reagent_containers/condiment/peppermill{pixel_x = 2},/obj/machinery/light/cold/directional/south,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"BN" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/structure/chair{dir = 4},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"BO" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"BS" = (/obj/structure/disposalpipe/segment,/obj/machinery/door/firedoor,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"BV" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"Cb" = (/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 1},/obj/effect/turf_decal/siding/wideplating/dark{dir = 1},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Cd" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/segment{dir = 10},/obj/machinery/duct,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Ce" = (/obj/structure/drain,/obj/machinery/shower/directional/east,/obj/effect/turf_decal/siding/thinplating/end{dir = 4},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Cf" = (/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Ch" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/effect/turf_decal/siding/wood,/obj/machinery/door/window/survival_pod{req_access = list("syndicate"); name = "Diner"},/obj/structure/disposalpipe/segment{dir = 6},/obj/structure/cable,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Cj" = (/obj/machinery/light/cold/directional/west,/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"Cm" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/corporateliaison,/turf/open/floor/carpet/donk,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"Cn" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/incinerator_syndicatelava_aux{name = "Combustion Chamber Blast Door"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Cp" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Cq" = (/obj/effect/turf_decal/skyrat_decals/departments/bridge{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_edge{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Ct" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/light/cold/directional/south,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Cy" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"CC" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/machinery/light/cold/directional/west,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"CE" = (/obj/structure/railing,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"CF" = (/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/miner,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"CH" = (/turf/open/floor/carpet/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"CJ" = (/obj/structure/window/reinforced/tinted{dir = 1},/obj/structure/window/reinforced/tinted{dir = 4},/obj/machinery/power/shuttle_engine/heater,/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"CS" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/turf_decal/siding/white{dir = 1},/obj/item/toy/figure/syndie{pixel_y = 20; pixel_x = 10},/obj/item/toy/figure/syndie{pixel_y = 23},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"CT" = (/obj/structure/chair/stool/directional/west,/obj/effect/turf_decal/stripes/red/line{dir = 10},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"CV" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/turf_decal/siding/white{dir = 1},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"CX" = (/obj/machinery/light/warm/directional/north,/obj/effect/turf_decal/siding/yellow{dir = 5},/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/enginetech{dir = 4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"De" = (/obj/effect/turf_decal/tile/brown{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Dh" = (/obj/effect/turf_decal/delivery/red,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/stripes/red/line{dir = 1},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Dk" = (/obj/machinery/door/firedoor,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/recharger,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Dm" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Dr" = (/obj/machinery/seed_extractor,/obj/effect/turf_decal/bot_white,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Ds" = (/obj/structure/toilet{pixel_y = 16},/obj/effect/turf_decal/siding/dark{dir = 9},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Dt" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/effect/turf_decal/siding/dark/corner,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Du" = (/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/effect/turf_decal/siding/dark/corner{dir = 1},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Dv" = (/obj/effect/turf_decal/stripes/red/line,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Dw" = (/obj/structure/closet/emcloset,/obj/structure/cable,/obj/effect/turf_decal/tile/dark_red/half/contrasted{dir = 1},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 1},/obj/machinery/light/red/directional/south,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Dy" = (/obj/machinery/smartfridge/chemistry,/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"Dz" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 9},/obj/effect/turf_decal/siding/dark{dir = 9},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/obj/machinery/light/small/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"DA" = (/obj/effect/turf_decal/bot,/obj/item/disk{desc = "A cheap, plastic hard-disk labelled 'good tunes to assault ops to'. It looks disused... wait, is that a 'THE WEAPONIZED' logo?"; icon_state = "nucleardisk"; name = "dat fukken disk"},/obj/item/choice_beacon/music{pixel_x = 5},/obj/item/choice_beacon/music{pixel_y = -4; pixel_x = -3},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/closet/crate/wooden,/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/effect/turf_decal/tile/yellow/half{dir = 1},/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"DB" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"DE" = (/obj/structure/table/wood,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/obj/machinery/button/door{id = "TESArena"; name = "Dorm Bolt Control"; normaldoorcontrol = 1; pixel_x = -8; specialfunctions = 4; pixel_y = 24},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"DF" = (/obj/effect/turf_decal/siding/thinplating/dark,/obj/effect/turf_decal/trimline/dark_red/corner,/obj/effect/turf_decal/trimline/dark_red/line{dir = 9},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/structure/cable,/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/obj/machinery/fax{fax_name = "Unknown Syndicate Fax"; name = "DS-2 Fax Machine"; pixel_y = 7; syndicate_network = 1},/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"DH" = (/obj/effect/turf_decal/siding/dark{dir = 6},/obj/structure/table/glass,/obj/item/gun/energy/floragun{pixel_y = 7},/obj/item/geneshears,/obj/item/plant_analyzer{pixel_x = -7},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"DI" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/door/airlock/command{name = "E.V.A."},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/unres{dir = 8},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"DJ" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/wood{dir = 4},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"DK" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/side{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"DL" = (/obj/machinery/smartfridge,/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"DS" = (/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating/end{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/disposalpipe/trunk{dir = 4},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Eb" = (/obj/machinery/light/cold/directional/west,/obj/effect/turf_decal/vg_decals/atmos/nitrogen{dir = 4},/turf/open/floor/engine/n2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Ec" = (/obj/structure/transit_tube/station/dispenser/reverse,/obj/effect/turf_decal/stripes/line{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Ed" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Ej" = (/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating/end{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/disposalpipe/trunk{dir = 1},/obj/machinery/button/door{id = "ds2cargo"; pixel_x = 24; req_access = list("syndicate"); name = "Cargo Blastdoor Control"},/obj/structure/railing,/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Em" = (/obj/effect/turf_decal/tile/yellow/half,/obj/structure/sign/flag/syndicate/directional/south{pixel_x = -16},/obj/structure/rack/shelf,/obj/item/tank/internals/emergency_oxygen/double{pixel_y = 3; pixel_x = -2},/obj/item/clothing/mask/gas/alt{pixel_x = -2},/obj/item/tank/internals/emergency_oxygen/double{pixel_x = 6},/obj/item/clothing/mask/gas/alt{pixel_y = -3; pixel_x = 6},/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"En" = (/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Ew" = (/obj/structure/weightmachine/stacklifter,/obj/effect/turf_decal/box/white,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Ey" = (/obj/effect/turf_decal/siding/wood{dir = 4},/obj/structure/bookcase/random/nonfiction,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Ez" = (/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"EB" = (/obj/effect/turf_decal/bot,/obj/machinery/vending/engivend{onstation = 0},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"EC" = (/obj/structure/reagent_dispensers/wall/peppertank/directional/west,/obj/item/grenade/barrier{pixel_y = 10},/obj/item/grenade/barrier{pixel_y = 6; pixel_x = 4},/obj/item/grenade/barrier{pixel_y = 6; pixel_x = -4},/obj/item/grenade/barrier{pixel_y = 2},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/structure/table/reinforced,/obj/effect/turf_decal/siding/dark/corner{dir = 4},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"EJ" = (/obj/structure/lattice/catwalk,/obj/structure/marker_beacon/burgundy,/turf/template_noop,/area/template_noop)
-"EL" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"EP" = (/obj/machinery/light/warm/directional/north,/obj/machinery/vending/clothing,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"EQ" = (/obj/machinery/duct,/obj/structure/reagent_dispensers/water_cooler,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"ET" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/conveyor{id = "ds2disposals"},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/stripes/end,/obj/effect/spawner/random/trash/botanical_waste,/obj/effect/spawner/random/trash/food_packaging{pixel_x = -4; pixel_y = -3},/obj/item/trash/can/food/peaches{pixel_y = -6; pixel_x = 6},/turf/open/floor/iron/pool,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"EU" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair{dir = 1},/obj/structure/cable,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"EV" = (/obj/structure/weightmachine/stacklifter,/obj/machinery/light/warm/directional/north,/obj/effect/turf_decal/tile/neutral/half/contrasted{dir = 1},/obj/effect/turf_decal/trimline/dark/line{dir = 1},/obj/effect/turf_decal/trimline/dark/line{dir = 1},/obj/machinery/firealarm/directional/north,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"EW" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue,/obj/machinery/light/cold/directional/south,/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"EY" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"EZ" = (/obj/effect/spawner/random/contraband/prison,/obj/structure/closet/crate/bin,/obj/effect/spawner/random/trash/food_packaging{pixel_y = -5},/obj/effect/spawner/random/trash/cigbutt,/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Fa" = (/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Fb" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/structure/cable,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Fc" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden{dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Fe" = (/obj/structure/chair/office{dir = 1},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Fh" = (/obj/effect/turf_decal/stripes/red/line,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Fi" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/effect/turf_decal/siding/wood,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 10},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Fj" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Fk" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/shutters{name = "Master At Arms Shutters"; id = "smasteratarms"; dir = 4},/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Fl" = (/turf/open/floor/engine/o2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Fm" = (/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/machinery/door/firedoor,/obj/machinery/door/airlock/research{name = "Research"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Fo" = (/obj/effect/turf_decal/stripes/red/corner,/obj/effect/turf_decal/siding/dark/corner,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Fw" = (/obj/machinery/shower/directional/south,/obj/effect/turf_decal/siding/dark{dir = 5},/obj/structure/drain,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"Fx" = (/obj/machinery/hydroponics/constructable,/obj/machinery/door/window/survival_pod{dir = 4; pixel_x = 4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"Fy" = (/obj/effect/turf_decal/delivery/red,/obj/machinery/door/poddoor/shutters{name = "Armory Shutters"; id = "ds2armory"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Fz" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"FA" = (/obj/machinery/sleeper/syndie/fullupgrade{dir = 4},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 9},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"FB" = (/obj/structure/chair/office/light,/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"FC" = (/obj/structure/cable,/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"FD" = (/obj/effect/turf_decal/siding/wood,/obj/item/kirbyplants{icon_state = "plant-21"},/obj/machinery/button/door/directional/north{desc = "Keep out the paperwork."; id = "scorpliaison"; name = "Corporate Liaison's room bolt"; normaldoorcontrol = 1; req_access = list("syndicate_leader"); specialfunctions = 4},/obj/machinery/light/warm/directional/west,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"FG" = (/obj/effect/turf_decal/tile/purple{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"FH" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"FJ" = (/obj/effect/turf_decal/siding/dark{dir = 10},/obj/structure/table/reinforced,/obj/item/storage/box/beakers{pixel_x = 3; pixel_y = 3},/obj/item/storage/box/syringes,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"FO" = (/obj/structure/closet/secure_closet{icon_state = "med_secure"; name = "medical gear locker"; req_access = list("syndicate")},/obj/item/clothing/gloves/color/latex/nitrile/ntrauma,/obj/item/clothing/suit/toggle/labcoat/interdyne,/obj/item/clothing/suit/toggle/labcoat/interdyne,/obj/item/storage/belt/medbandolier{pixel_x = -2; pixel_y = 2},/obj/item/storage/belt/medbandolier{pixel_x = 2; pixel_y = -2},/obj/item/clothing/glasses/hud/ar/aviator/health,/obj/item/clothing/glasses/hud/ar/aviator/health,/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"FP" = (/obj/machinery/computer/crew/syndie{dir = 4},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"FY" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"FZ" = (/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Gb" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Gd" = (/obj/effect/turf_decal/stripes/line{dir = 6},/obj/machinery/light/red/directional/south,/obj/effect/turf_decal/siding/white{dir = 6},/obj/item/toy/figure/syndie{pixel_y = -1; pixel_x = -12},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Ge" = (/obj/effect/turf_decal/stripes/red/line,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Gg" = (/obj/effect/turf_decal/siding/wood{dir = 10},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Gh" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 10},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/button/curtain{id = "DS2cell1"; name = "curtain control"; pixel_y = -24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Gi" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Gk" = (/obj/machinery/power/turbine/core_rotor{mapping_id = "syndicatelava_turbine"},/obj/structure/cable,/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Gl" = (/obj/structure/window/reinforced/survival_pod,/obj/effect/turf_decal/siding/dark,/obj/structure/table,/obj/item/choice_beacon/ingredient{pixel_y = 11},/obj/item/choice_beacon/ingredient{pixel_y = 2; pixel_x = -5},/obj/structure/cable,/obj/item/clothing/accessory/armband/hydro{desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."; name = "service armband"; pixel_x = 15},/obj/item/reagent_containers/condiment/enzyme{pixel_y = 8; pixel_x = 17},/obj/item/storage/belt/military/snack,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Gt" = (/obj/effect/turf_decal/siding/wood{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Gx" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Gz" = (/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"GD" = (/obj/effect/turf_decal/siding/dark,/obj/structure/table,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"GE" = (/obj/effect/turf_decal/bot,/obj/effect/spawner/random/maintenance/two,/obj/structure/closet/crate,/obj/effect/spawner/random/engineering/flashlight,/obj/effect/spawner/random/clothing/twentyfive_percent_cyborg_mask,/obj/effect/spawner/random/engineering/tool,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"GG" = (/obj/machinery/cryopod{dir = 4},/obj/effect/turf_decal/trimline/dark_green/filled/line{dir = 8},/obj/effect/turf_decal/trimline/dark_green/filled/line{dir = 4},/obj/effect/turf_decal/siding/thinplating/dark{dir = 4},/turf/open/floor/iron/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"GH" = (/obj/effect/turf_decal/bot,/obj/structure/closet/crate/freezer/surplus_limbs,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"GK" = (/obj/machinery/power/shuttle_engine/huge,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"GL" = (/obj/effect/turf_decal/bot_white,/obj/structure/closet/crate,/obj/effect/spawner/random/contraband/prison,/obj/item/canvas/twentythree_twentythree,/obj/item/canvas/twentythree_twentythree,/obj/item/toy/crayon/spraycan{pixel_y = 9; pixel_x = -5},/obj/item/toy/crayon/spraycan{pixel_y = 9; pixel_x = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"GO" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/red/corner,/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"GR" = (/obj/effect/turf_decal/bot,/obj/structure/reagent_dispensers/fueltank,/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/effect/decal/cleanable/oil,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"GS" = (/obj/effect/turf_decal/siding/wood{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"GU" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"GV" = (/obj/structure/table/wood,/obj/item/camera{pixel_x = -9; pixel_y = 6},/obj/item/paper{default_raw_text = "<h1>DS2 Command Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>The Sothran Syndicate is glad to have you on-field, admiral. Nanotrasen is in the direct sector and, as such, is the direct target of our operatives. Manage your crew well and with respect, and leave all your anger to the gravel that is Nanotrasen. Remember that Interdyne has an unaffiliated facade to keep up, as such, advise against your crew flaunting their affiliation to non-crew.</p><p>Stay winning.</p>"; name = "paper- 'DS2 Command Report'"},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"GX" = (/obj/structure/sign/flag/syndicate/directional/south{pixel_x = 16},/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/siding/white,/obj/item/toy/figure/syndie{pixel_x = -10},/obj/item/toy/figure/syndie{pixel_y = -3; pixel_x = 4},/obj/structure/shipping_container/donk_co{pixel_x = -17; pixel_y = 15; desc = "A standard-measure shipping container for bulk transport of goods. This one is from Donk Co. and so could be carrying just about anything- although it seems this one is overflowing with little Syndicate Figurines, known for being sold at a Loss."},/turf/open/floor/plating/elevatorshaft,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"GY" = (/obj/effect/turf_decal/siding/wood{dir = 5},/obj/structure/chair/sofa/corp/left{color = "#DE3A3A"},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Ha" = (/obj/machinery/door/firedoor,/obj/machinery/door/window/survival_pod{req_access = list("syndicate_leader"); dir = 4},/obj/structure/table/reinforced/plastitaniumglass,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Hb" = (/obj/effect/turf_decal/siding/wood{dir = 1},/obj/structure/chair/sofa/corp{color = "#DE3A3A"},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Hc" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/light/cold/directional/west,/obj/structure/rack/gunrack,/obj/item/gun/ballistic/shotgun/riot/syndicate,/obj/item/gun/ballistic/shotgun/riot/syndicate{pixel_x = -10},/obj/item/gun/ballistic/shotgun/riot/syndicate{pixel_x = -5; pixel_y = -3},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Hh" = (/obj/structure/table,/obj/machinery/light/cold/directional/east,/obj/machinery/microwave{pixel_y = 5},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Hn" = (/obj/effect/turf_decal/siding/dark,/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Hq" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 4},/obj/effect/turf_decal/trimline/dark_red/line{dir = 8},/obj/effect/turf_decal/trimline/dark_red/line{dir = 4},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 8},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Hr" = (/obj/machinery/oven,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Ht" = (/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/machinery/computer/shuttle{desc = "A shuttle terminal which allows a connection to the DS-2 forward base's supply shuttle."; icon_keyboard = "syndie_key"; icon_screen = "syndishuttle"; light_color = "#FA8282"; name = "syndicate cargo shuttle terminal"; possible_destinations = "IP-DS-2"; req_access = list("syndicate"); shuttleId = "syndie_cargo"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Hu" = (/obj/structure/closet/crate,/obj/item/reagent_containers/cup/bowl,/obj/effect/spawner/random/contraband/prison,/obj/item/reagent_containers/cup/bowl,/obj/item/reagent_containers/cup/bowl,/obj/item/reagent_containers/cup/bowl,/obj/item/reagent_containers/cup/bowl,/obj/item/reagent_containers/cup/bowl,/obj/item/reagent_containers/cup/bowl,/obj/item/reagent_containers/cup/bowl,/obj/item/kitchen/fork/plastic,/obj/item/kitchen/fork/plastic,/obj/item/kitchen/fork/plastic,/obj/item/storage/box/drinkingglasses,/obj/item/kitchen/spoon/plastic,/obj/item/kitchen/spoon/plastic,/obj/item/kitchen/spoon/plastic,/obj/item/knife/plastic,/obj/item/knife/plastic,/obj/item/knife/plastic,/obj/item/kitchen/rollingpin,/obj/item/storage/box/drinkingglasses,/obj/effect/turf_decal/bot_white,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Hw" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 1},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Hz" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"HA" = (/obj/item/book/manual/wiki/chemistry{pixel_x = -4},/obj/item/clothing/glasses/science{pixel_x = -4},/obj/structure/table/reinforced/plastitaniumglass,/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"HD" = (/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/effect/turf_decal/box/white/corners{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"HE" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 6},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"HF" = (/obj/machinery/suit_storage_unit/syndicate/chameleon{name = "suit storage unit"},/obj/effect/turf_decal/siding/yellow{dir = 8},/obj/effect/turf_decal/trimline/yellow/filled/line{dir = 4},/obj/effect/turf_decal/trimline/yellow/warning{dir = 8},/obj/effect/turf_decal/trimline/yellow/line{dir = 4},/turf/open/floor/iron/dark/side{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"HH" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"HI" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"HK" = (/obj/machinery/conveyor{dir = 4; id = "ds2conveyor"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"HV" = (/obj/machinery/conveyor{dir = 4; id = "ds2conveyor"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"HZ" = (/obj/structure/cable,/obj/effect/turf_decal/siding/dark,/obj/structure/disposalpipe/segment{dir = 5},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Ia" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"Ih" = (/obj/effect/turf_decal/trimline/yellow/warning{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Ii" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"Im" = (/obj/structure/cable,/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/disposalpipe/segment{dir = 2},/obj/machinery/light/warm/directional/east,/obj/structure/extinguisher_cabinet/directional/east,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Io" = (/obj/effect/turf_decal/stripes/line{dir = 9},/obj/structure/cable,/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Ir" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Iw" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"IA" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/chair/sofa/bench/corner{dir = 1},/obj/item/kirbyplants{icon_state = "plant-18"},/obj/machinery/light/cold/directional/south,/obj/machinery/power/apc/auto_name/directional/south{req_access = list("syndicate")},/obj/structure/cable,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"IC" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/light/floor{use_power = 0},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"IH" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 5},/obj/item/circuitboard/machine/destructive_analyzer,/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"IM" = (/obj/structure/closet/crate/medical,/obj/effect/turf_decal/bot,/obj/effect/spawner/random/medical/medkit{pixel_y = 3; pixel_x = 6},/obj/effect/spawner/random/medical/supplies{pixel_y = 3},/obj/effect/spawner/random/medical/medkit{pixel_y = -3; pixel_x = -6},/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"IN" = (/obj/structure/table/wood,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/obj/item/sign/flag/syndicate{pixel_y = 6; pixel_x = -3},/obj/item/reagent_containers/cup/maunamug{pixel_x = 4},/turf/open/floor/carpet/donk,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"IQ" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"IU" = (/obj/item/circuitboard/machine/ammo_workbench,/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/obj/item/disk/ammo_workbench/lethal,/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"IV" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"IZ" = (/obj/effect/turf_decal/siding/wood{dir = 6},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 10},/obj/machinery/suit_storage_unit{mask_type = /obj/item/clothing/mask/gas/syndicate; storage_type = /obj/item/tank/jetpack/oxygen/harness; mod_type = /obj/item/mod/control/pre_equipped/traitor_elite},/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"Jd" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"Jf" = (/obj/structure/closet/secure_closet/freezer/kitchen{req_access = null},/obj/item/food/breadslice/plain,/obj/item/food/breadslice/plain,/obj/item/food/breadslice/plain,/obj/item/food/grown/potato,/obj/item/food/grown/potato,/obj/effect/spawner/random/contraband/permabrig_weapon,/obj/item/food/grown/onion,/obj/item/food/grown/onion,/obj/item/storage/box/ingredients/random,/obj/item/storage/box/ingredients/random,/obj/effect/turf_decal/bot_white,/obj/item/storage/box/ingredients/carnivore,/obj/item/storage/box/ingredients/wildcard,/obj/item/storage/fancy/egg_box,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Jl" = (/obj/machinery/light/cold/directional/west,/obj/structure/table,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/item/trash/empty_food_tray{pixel_y = 7},/obj/item/newspaper{pixel_x = 5; pixel_y = -1},/obj/item/trash/can{pixel_x = -9},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Jv" = (/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Jy" = (/obj/machinery/door/firedoor,/obj/effect/turf_decal/stripes/red/corner,/obj/effect/turf_decal/trimline/yellow/corner{dir = 8},/obj/structure/disposalpipe/segment{dir = 8},/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Jz" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"JA" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/chair/stool/directional/west,/obj/effect/turf_decal/stripes/red/line{dir = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"JB" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/effect/turf_decal/siding/dark,/obj/structure/cable,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"JC" = (/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"JD" = (/obj/structure/closet/secure_closet{icon_state = "warden"; name = "master at arms' locker"; req_access = list("syndicate_leader")},/obj/item/storage/belt/security/full,/obj/item/radio/headset/interdyne,/obj/item/clothing/suit/armor/vest/warden/syndicate,/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,/obj/item/clothing/head/beret/sec/navywarden/syndicate,/obj/item/clothing/under/suit/skyrat/helltaker{has_sensor = 0; random_sensor = 0},/obj/item/clothing/suit/armor/hos/trenchcoat{armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "fire" = 50, "acid" = 50, "wound" = 10); desc = "A trenchcoat enhanced with a special lightweight kevlar. It has little Syndicate logos sewn onto the shoulder badges with the letters 'MAA' just under it."; name = "Master at arms' armored trenchcoat"},/obj/item/clothing/suit/armor/hos{armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "fire" = 50, "acid" = 50, "wound" = 10); desc = "A greatcoat enhanced with a special alloy for some extra protection and style for those with a likely chance to get bullied for being outside of the brig"; name = "Master at arms' armored greatcoat"},/obj/item/gun/energy/disabler,/obj/item/clothing/head/hos/beret/syndicate,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/item/clothing/mask/gas/sechailer/syndicate,/obj/item/watertank/pepperspray,/obj/item/clothing/accessory/medal/silver{name = "military excellence medal"; desc = "The Sothran Syndicate's dictionary defines excellence as \"the ability to crush NT scum under one's boot\". This is awarded to those rare operatives who fit that definition."},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"JE" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/wood{dir = 10},/obj/structure/cable,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"JF" = (/obj/effect/turf_decal/trimline/dark_blue/line{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/light/cold/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"JI" = (/obj/effect/turf_decal/siding/wood{dir = 6},/obj/machinery/vending/cigarette/syndicate,/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"JK" = (/obj/structure/rack/shelf,/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 8},/obj/item/ai_module/reset/purge{pixel_y = -7; pixel_x = -2},/obj/item/ai_module/reset/purge{pixel_y = -4},/obj/item/ai_module/supplied/freeform{pixel_y = 4; pixel_x = -2},/obj/item/ai_module/supplied/freeform{pixel_y = 7},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"JL" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"JN" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_blue/corner{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"JR" = (/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"JS" = (/obj/machinery/button/door/directional/east{desc = "To keep the void away."; id = "ds2bridge"; name = "Bridge Blast Door Control"; req_access = list("syndicate_leader"); pixel_y = 32},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"JZ" = (/obj/structure/disposalpipe/segment{dir = 2},/obj/machinery/light/small/red/directional/east,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/camera/xray/directional/east{c_tag = "DS-2 Engineering Airlock"; network = list("ds2")},/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Kb" = (/obj/machinery/door/window/survival_pod{dir = 1; req_access = list("syndicate_leader")},/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Kd" = (/obj/effect/turf_decal/skyrat_decals/syndicate/bottom/right,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Ke" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Kf" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"Kg" = (/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Kh" = (/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/effect/turf_decal/bot,/obj/effect/spawner/random/mod/maint,/obj/effect/spawner/random/mod/maint{pixel_y = -3},/obj/effect/spawner/random/mod/maint{pixel_y = -6},/obj/structure/closet/crate/science,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Kj" = (/obj/effect/turf_decal/trimline/dark_green/warning{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Kk" = (/obj/effect/turf_decal/tile/dark_red/half/contrasted{dir = 4},/obj/structure/cable,/obj/structure/disposalpipe/segment{dir = 2},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Ku" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 10},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Kz" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/obj/structure/railing/corner,/obj/effect/turf_decal/stripes/end,/obj/effect/turf_decal/siding/dark/end,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"KC" = (/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"KG" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"KI" = (/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/effect/turf_decal/stripes/red/corner{dir = 4},/obj/effect/turf_decal/box/white/corners,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"KJ" = (/obj/structure/table/reinforced,/obj/machinery/light/cold/directional/north,/obj/item/storage/toolbox/electrical{pixel_x = 4; pixel_y = 4},/obj/item/storage/toolbox/mechanical,/obj/item/stack/rods/fifty{pixel_y = 5},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"KM" = (/obj/structure/chair/stool/directional/east,/obj/effect/turf_decal/stripes/red/line,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"KN" = (/obj/machinery/door/airlock/security/old/glass{name = "Security"},/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/delivery/red,/obj/structure/cable,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 2},/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{cycle_id = "DS2brig"},/obj/effect/mapping_helpers/airlock/unres,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"KQ" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/tile/dark_red/half{dir = 4},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 4},/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"KS" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"KT" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/obj/structure/closet/l3closet/scientist,/turf/open/floor/iron/dark/side{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"KV" = (/obj/effect/turf_decal/siding/wideplating_new/dark/corner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"KY" = (/obj/effect/turf_decal/siding/wood{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"Lb" = (/obj/effect/turf_decal/tile/dark_red/half,/obj/effect/turf_decal/siding/wideplating_new/dark,/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Le" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/carpet/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"Lf" = (/obj/effect/turf_decal/siding/wood,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"Lg" = (/obj/machinery/atmospherics/miner/plasma,/turf/open/floor/engine/plasma,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Ll" = (/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Lo" = (/obj/effect/turf_decal/trimline/yellow/line{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Lq" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Lr" = (/obj/machinery/oven,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Ls" = (/obj/effect/turf_decal/siding/yellow{dir = 4},/obj/effect/turf_decal/trimline/yellow/filled/line{dir = 8},/obj/effect/turf_decal/trimline/yellow/warning{dir = 4},/obj/effect/turf_decal/trimline/yellow/line{dir = 8},/obj/structure/closet/secure_closet{icon_state = "eng"; name = "welding supplies locker"; req_access = list("syndicate"); icon_door = "eng_weld"},/obj/item/weldingtool/largetank{pixel_y = 4},/obj/item/weldingtool/largetank{pixel_y = -3},/obj/item/clothing/glasses/welding{pixel_y = 4},/obj/item/clothing/glasses/welding{pixel_y = -3},/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Lv" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/item/storage/belt/holster/nukie{pixel_x = -6; pixel_y = 10},/obj/item/storage/belt/holster/nukie{pixel_y = 6},/obj/item/storage/belt/holster/nukie{pixel_x = 9},/obj/item/clothing/suit/armor/vest{pixel_x = -5; pixel_y = 5},/obj/item/clothing/suit/armor/vest{pixel_x = 1; pixel_y = 2},/obj/item/clothing/suit/armor/vest{pixel_x = 7; pixel_y = -1},/obj/item/storage/belt/military{pixel_x = -8},/obj/item/storage/belt/military{pixel_x = 1; pixel_y = -3},/obj/item/storage/belt/military{pixel_x = 8; pixel_y = -6},/obj/item/clothing/head/helmet{pixel_x = -6; pixel_y = -4},/obj/item/clothing/head/helmet{pixel_y = -7},/obj/item/clothing/head/helmet{pixel_x = 6; pixel_y = -11},/obj/structure/closet/secure_closet{icon_state = "riot"; name = "armory gear locker"; req_access = list("syndicate_leader"); icon = 'modular_skyrat/master_files/icons/obj/closet.dmi'; anchored = 1},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Lw" = (/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Lx" = (/obj/machinery/door/airlock/security/old{hackProof = 1; name = "Master At Arms' Office"; id_tag = "smasteratarms"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/delivery/red,/obj/effect/mapping_helpers/airlock/locked,/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/effect/turf_decal/stripes/red/line,/obj/effect/mapping_helpers/airlock/unres{dir = 1},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Lz" = (/obj/structure/disposalpipe/segment,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"LA" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/line,/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"LB" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/researcher,/turf/open/floor/iron/dark/side{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"LG" = (/obj/effect/turf_decal/siding/wood,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"LK" = (/obj/structure/sign/flag/syndicate/directional/south,/obj/machinery/light/warm/directional/south,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"LM" = (/obj/machinery/conveyor{dir = 8; id = "ds2conveyor"},/obj/structure/railing,/obj/machinery/door/poddoor{id = "ds2cargo"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"LP" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"LQ" = (/obj/structure/table/wood,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/machinery/firealarm/directional/south,/obj/item/poster/random_contraband{pixel_y = 5; pixel_x = 5},/obj/item/poster/random_contraband,/obj/item/poster/random_contraband{pixel_y = 5; pixel_x = 2},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"LT" = (/obj/structure/toilet{pixel_y = 10},/obj/effect/turf_decal/siding/dark{dir = 5},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"LV" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/enginetech{dir = 8},/obj/machinery/light/warm/directional/north,/obj/effect/turf_decal/siding/yellow{dir = 9},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"LY" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/cable,/obj/machinery/camera/xray/directional/south{network = list("ds2"); c_tag = "DS-2 Armory"},/obj/structure/table/reinforced,/obj/effect/turf_decal/siding/dark{dir = 5},/obj/item/storage/box/pinpointer_pairs{pixel_y = 6; pixel_x = -4},/obj/item/storage/box/pinpointer_pairs,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Mg" = (/obj/structure/chair/office/light{dir = 8},/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Mk" = (/obj/structure/table/reinforced/plastitaniumglass,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Mn" = (/obj/effect/turf_decal/trimline/dark_blue/filled/line,/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Mo" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Mt" = (/obj/machinery/porta_turret/syndicate/energy{dir = 5},/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"Mw" = (/obj/structure/table,/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/item/plate,/obj/item/food/poutine{pixel_y = 2},/obj/item/food/poutine{pixel_y = 5},/obj/machinery/light/warm/directional/west,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"MB" = (/obj/item/clothing/suit/toggle/labcoat/skyrat/hospitalgown{pixel_y = 4; pixel_x = -3},/obj/item/clothing/suit/toggle/labcoat/skyrat/hospitalgown{pixel_x = -7},/obj/structure/table/glass,/obj/item/reagent_containers/cup/glass/waterbottle{pixel_x = 8; pixel_y = 4},/obj/effect/turf_decal/tile/dark_blue/full,/obj/machinery/light/cold/directional/north,/obj/effect/turf_decal/siding/white,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"MC" = (/obj/structure/table/wood,/obj/item/paper_bin/carbon{pixel_y = 3},/obj/item/pen/fountain/captain{name = "admiral's fountain pen"; pixel_y = 5},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"ME" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/shutters{name = "Admiral Shutters"; id = "ds2admiral"; dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"MF" = (/obj/effect/turf_decal/bot_blue,/obj/structure/closet/secure_closet/freezer/meat{req_access = list("syndicate")},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"MG" = (/obj/structure/drain,/obj/machinery/shower/directional/east{pixel_x = -13},/obj/effect/turf_decal/siding/thinplating{dir = 6},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"MH" = (/obj/structure/table/reinforced,/obj/machinery/recharger,/obj/machinery/firealarm/directional/north,/obj/machinery/camera/xray/directional/east{network = list("ds2"); c_tag = "DS-2 EVA"},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"MK" = (/obj/structure/chair{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"MM" = (/obj/effect/turf_decal/siding/wood{dir = 6},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"MP" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"MT" = (/obj/machinery/computer/shuttle{desc = "A shuttle terminal which allows a connection to the DS-2 forward base's supply shuttle."; icon_keyboard = "syndie_key"; icon_screen = "syndishuttle"; light_color = "#FA8282"; name = "syndicate cargo shuttle terminal"; possible_destinations = "IP-DS-2"; req_access = list("syndicate"); shuttleId = "syndie_cargo"},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"MZ" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 4},/obj/effect/turf_decal/trimline/dark_red/line{dir = 8},/obj/effect/turf_decal/trimline/dark_red/line{dir = 4},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 8},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 4},/obj/structure/sign/flag/syndicate/directional/north,/obj/structure/showcase/cyborg{icon = 'icons/mob/silicon/robots.dmi'; icon_state = "synd_sec"; name = "syndicate cyborg showcase"; desc = "A stand with the empty body of a Cybersun cyborg bolted to it."; dir = 4; pixel_x = -6},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Nb" = (/obj/effect/turf_decal/stripes/red/corner,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/effect/turf_decal/box/white/corners{dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Nc" = (/obj/effect/turf_decal/stripes/line{dir = 1},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"Ne" = (/obj/effect/turf_decal/siding/wood{dir = 10},/obj/machinery/button/door/directional/south{id = "dorms-view"; req_access = list("syndicate"); name = "Dorms Blast Door Control"},/obj/structure/chair/sofa/corp/right{color = "#DE3A3A"; dir = 4},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"Ng" = (/obj/effect/turf_decal/vg_decals/atmos/plasma{dir = 4},/turf/open/floor/engine/plasma,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Ni" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/chair/stool/bar/directional/south,/obj/item/paint_palette,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Nk" = (/obj/machinery/door/airlock/command{name = "Bridge"; hackProof = 1},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/mapping_helpers/airlock/unres{dir = 8},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Nl" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/researcher,/obj/machinery/firealarm/directional/north,/turf/open/floor/iron/dark/side{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Nm" = (/obj/effect/turf_decal/siding/wood{dir = 1},/obj/structure/chair/comfy/brown{color = "#596479"; dir = 8},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"No" = (/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/door/airlock/silver/glass{name = "Kitchen"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"Nr" = (/obj/structure/table/reinforced/plastitaniumglass,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Ns" = (/obj/structure/sign/flag/syndicate/directional/north{pixel_x = 16},/obj/effect/turf_decal/tile/dark_red/half,/obj/effect/turf_decal/siding/wideplating_new/dark,/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"NA" = (/obj/effect/turf_decal/tile/dark_red/half/contrasted{dir = 4},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 4},/obj/structure/cable,/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/button/door/incinerator_vent_syndicatelava_aux{pixel_y = 24; pixel_x = -6; name = "Combustion Chamber Blast Door Control"},/obj/machinery/button/door/incinerator_vent_syndicatelava_main{pixel_x = -6; pixel_y = -24; name = "Turbine Exterior Vent Control"},/obj/machinery/door/window/survival_pod{dir = 8; req_access = list("syndicate")},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"NB" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob)
-"NC" = (/turf/open/floor/engine/n2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"NG" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/airalarm/syndicate{pixel_y = -24},/obj/machinery/door/firedoor,/obj/structure/cable,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"NL" = (/obj/structure/cable,/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/arrows,/obj/effect/turf_decal/box/corners{dir = 8},/obj/effect/turf_decal/box/corners,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"NN" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"NO" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/public/glass{name = "Fitness"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"NP" = (/obj/item/storage/belt/security/full,/obj/item/radio/headset/interdyne,/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,/obj/item/storage/belt/security/webbing/ds,/obj/item/clothing/head/beret/sec/syndicate,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/item/clothing/accessory/armband{name = "brig officer armband"; desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."},/obj/structure/closet/secure_closet{icon_state = "sec"; name = "brig officer gear locker"; req_access = list("syndicate_leader")},/obj/item/clothing/mask/gas/syndicate/ds,/obj/item/clothing/suit/toggle/jacket/sec/old{name = "brig officer jacket"},/obj/item/clothing/mask/gas/sechailer/syndicate,/obj/item/gun/energy/disabler,/obj/item/clothing/glasses/hud/security/sunglasses/eyepatch/redsec,/obj/item/clothing/glasses/hud/security/sunglasses/redsec,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"NQ" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"NR" = (/obj/machinery/conveyor{dir = 8; id = "ds2conveyor"},/obj/structure/railing,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"NS" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 6},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/table,/obj/item/storage/box/hug{pixel_x = 4; pixel_y = 3},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"NT" = (/obj/effect/turf_decal/trimline/blue/line{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/turf/open/floor/iron/dark/textured_edge{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"NW" = (/obj/structure/chair{dir = 1},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"NX" = (/obj/structure/chair/comfy/brown{color = "#596479"},/obj/machinery/light/warm/directional/north,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"NY" = (/obj/structure/closet/firecloset/full,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Ob" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 9},/obj/effect/turf_decal/trimline/dark_red/corner,/obj/effect/turf_decal/trimline/dark_red/line{dir = 9},/turf/open/floor/iron/dark/textured_corner,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Oc" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/warm/directional/west,/obj/machinery/firealarm/directional/west,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Od" = (/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{dir = 8; pixel_y = 4},/obj/structure/table/wood,/obj/machinery/firealarm/directional/east,/obj/item/reagent_containers/cup/glass/shaker{pixel_y = -7; pixel_x = -6},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Oe" = (/obj/structure/punching_bag,/obj/effect/turf_decal/box/white,/obj/item/reagent_containers/cup/glass/waterbottle{pixel_x = 11},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Oi" = (/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"Ok" = (/obj/structure/window/reinforced/survival_pod{dir = 10},/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Op" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/machinery/light/warm/directional/east,/obj/machinery/vending/snack,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Ov" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/siding/dark{dir = 4},/obj/item/restraints/handcuffs{pixel_y = 17},/obj/item/assembly/flash/handheld{pixel_y = 10; pixel_x = 3},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/item/crowbar/red,/obj/item/assembly/flash/handheld{pixel_y = 7; pixel_x = -6},/obj/structure/reagent_dispensers/wall/peppertank/directional/west,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Ox" = (/obj/machinery/sleeper/syndie/fullupgrade{dir = 4},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 10},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Oy" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"OC" = (/obj/item/storage/belt/security/full,/obj/item/radio/headset/interdyne,/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,/obj/item/storage/belt/security/webbing/ds,/obj/item/clothing/head/beret/sec/syndicate,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 10},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/item/clothing/accessory/armband{name = "brig officer armband"; desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/obj/structure/closet/secure_closet{icon_state = "sec"; name = "brig officer gear locker"; req_access = list("syndicate_leader")},/obj/item/clothing/mask/gas/syndicate/ds,/obj/item/clothing/suit/toggle/jacket/sec/old{name = "brig officer jacket"},/obj/item/clothing/mask/gas/sechailer/syndicate,/obj/item/gun/energy/disabler,/obj/item/clothing/glasses/hud/security/sunglasses/eyepatch/redsec,/obj/item/clothing/glasses/hud/security/sunglasses/redsec,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"OD" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/line{dir = 10},/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"OF" = (/obj/effect/turf_decal/trimline/dark_green/warning{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"OK" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"ON" = (/obj/machinery/atmospherics/miner/nitrogen,/turf/open/floor/engine/n2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"OP" = (/obj/effect/turf_decal/skyrat_decals/syndicate/top/left,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"OT" = (/obj/machinery/cryopod{dir = 8},/obj/effect/turf_decal/delivery/white{color = "#00ff00"; name = "green"},/obj/machinery/computer/cryopod/interdyne{dir = 8; pixel_x = 24},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"OU" = (/obj/effect/turf_decal/trimline/dark_green/corner{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Pe" = (/obj/effect/turf_decal/siding/wood{dir = 9},/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/north,/obj/structure/chair/sofa/corp/left{color = "#DE3A3A"; dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"Pf" = (/obj/structure/chair{dir = 1},/obj/effect/turf_decal/siding/wood{dir = 4},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"Pi" = (/obj/structure/railing/corner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/conveyor_switch/oneway{id = "ds2disposals"; pixel_y = 12},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Pn" = (/obj/effect/turf_decal/stripes/line{dir = 10},/obj/effect/turf_decal/siding/dark{dir = 10},/obj/machinery/atmospherics/components/binary/valve/digital{dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Po" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/vg_decals/numbers/one,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Pq" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/camera/xray/directional/west{network = list("ds2"); c_tag = "DS-2 Engineering"},/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Pt" = (/obj/effect/turf_decal/siding/thinplating/dark,/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/line{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/structure/chair/office{dir = 1},/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Px" = (/obj/effect/turf_decal/siding/dark,/obj/structure/window/reinforced/survival_pod,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Py" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/delivery/red,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/door/firedoor,/obj/machinery/door/airlock/grunge{name = "Cell 2"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"PA" = (/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/obj/machinery/light/cold/directional/north,/obj/structure/closet/secure_closet{icon_state = "science"; name = "scientist gear locker"; req_access = list("syndicate")},/obj/item/clothing/under/rank/rnd/scientist/skyrat/utility/syndicate,/obj/item/clothing/suit/hooded/wintercoat/science,/obj/item/clothing/suit/toggle/labcoat/science,/obj/item/clothing/under/rank/rnd/scientist/skyrat/utility/syndicate{pixel_y = -3},/obj/item/clothing/glasses/sunglasses/chemical,/obj/item/clothing/accessory/armband/science{desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."; name = "researcher armband"},/obj/item/clothing/accessory/armband/science{desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."; name = "researcher armband"},/turf/open/floor/iron/dark/side{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"PM" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/purple/corner{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/ore_box,/obj/effect/turf_decal/bot,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"PO" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/obj/effect/turf_decal/siding/yellow{dir = 4},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"PP" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"PR" = (/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/firealarm/directional/south,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"PS" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"PU" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/grill,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"PV" = (/obj/effect/turf_decal/trimline/dark_blue/filled/corner{dir = 8},/obj/effect/turf_decal/siding/dark/corner{dir = 8},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"PW" = (/obj/effect/turf_decal/siding/dark,/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/structure/reagent_dispensers/watertank/high,/obj/item/reagent_containers/cup/bucket,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"PX" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"PY" = (/obj/structure/punching_bag,/turf/open/floor/carpet/blue,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"Qa" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Qb" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Qe" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Qh" = (/obj/effect/turf_decal/trimline/purple/line{dir = 4},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Qi" = (/obj/structure/mirror/directional/north,/obj/structure/sink/directional/south,/obj/effect/turf_decal/siding/dark{dir = 5},/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Qo" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/structure/sink/directional/south,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"Qp" = (/obj/structure/transit_tube/station/dispenser/reverse/flipped{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 10},/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Qs" = (/obj/effect/turf_decal/siding/wood{dir = 10},/obj/structure/bed/dogbed,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 6},/mob/living/simple_animal/pet/fox{name = "Rhials"},/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"Qw" = (/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/west{req_access = list("syndicate")},/obj/effect/turf_decal/trimline/brown/corner{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/arrows{pixel_y = 16},/obj/effect/turf_decal/box/corners{dir = 4},/obj/effect/turf_decal/box/corners{dir = 1},/obj/machinery/computer/order_console/mining/interdyne,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Qx" = (/obj/effect/turf_decal/stripes/red/corner,/obj/structure/weightmachine/weightlifter,/obj/effect/turf_decal/box/white,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Qz" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"QA" = (/obj/effect/turf_decal/bot,/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/effect/spawner/random/maintenance/five,/obj/effect/spawner/random/trash/janitor_supplies,/obj/structure/closet/crate,/obj/machinery/light/cold/directional/south,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"QB" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair{dir = 1},/obj/machinery/button/door/directional/east{desc = "To keep your food away from the carp."; id = "diner-view"; name = "Diner Blast Door Control"; req_access = list("syndicate"); pixel_y = -24},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"QC" = (/obj/effect/turf_decal/trimline/dark_green/corner,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/obj/machinery/light/cold/directional/east,/obj/structure/disposalpipe/junction{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"QE" = (/obj/machinery/power/apc/auto_name/directional/south{req_access = list("syndicate")},/obj/structure/cable,/obj/effect/turf_decal/tile/dark_red/anticorner{dir = 1},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 9},/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"QF" = (/obj/effect/turf_decal/stripes/line{dir = 9},/obj/effect/turf_decal/siding/dark{dir = 9},/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"QG" = (/obj/effect/turf_decal/box/red/corners{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"QH" = (/obj/item/folder/syndicate,/obj/item/laser_pointer/upgraded{pixel_y = 10},/obj/item/clothing/glasses/sunglasses,/obj/structure/table/wood,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"QK" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/tile/dark_red/half{dir = 4},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 4},/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"QM" = (/obj/item/kirbyplants{icon_state = "plant-10"},/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/obj/machinery/light/cold/directional/north,/turf/open/floor/iron/dark/side{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"QN" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"QO" = (/obj/structure/table/wood,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"QQ" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"QV" = (/obj/structure/chair/stool/directional/east,/obj/effect/turf_decal/stripes/red/line{dir = 1},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"QW" = (/obj/structure/chair/office/light{dir = 8},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"QY" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 1},/obj/effect/turf_decal/siding/wideplating/dark{dir = 1},/obj/machinery/light/cold/directional/west,/obj/structure/bed/roller,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Ra" = (/obj/effect/turf_decal/box/red/corners,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Rb" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"Rc" = (/obj/structure/disposalpipe/segment{dir = 1},/obj/machinery/firealarm/directional/east,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Rd" = (/obj/effect/turf_decal/siding/wood{dir = 5},/obj/structure/table/wood,/obj/machinery/computer/libraryconsole/bookmanagement{pixel_y = 7},/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Re" = (/obj/structure/chair{dir = 1},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"Rf" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Rh" = (/obj/machinery/vending/cola/red,/obj/machinery/airalarm/syndicate{dir = 4; pixel_x = 24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Rj" = (/obj/effect/turf_decal/siding/yellow{dir = 8},/obj/effect/turf_decal/trimline/yellow/filled/line{dir = 4},/obj/effect/turf_decal/trimline/yellow/warning{dir = 8},/obj/effect/turf_decal/trimline/yellow/line{dir = 4},/obj/structure/closet/radiation,/obj/item/mod/module/rad_protection,/obj/item/analyzer,/obj/item/mod/module/visor/meson{pixel_y = -9},/turf/open/floor/iron/dark/side{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Rm" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/cold/directional/west,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Rp" = (/obj/structure/sign/flag/syndicate/directional/north,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Rr" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/chair/stool/bar{dir = 4},/obj/effect/turf_decal/siding/wood{dir = 4},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Rt" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Ru" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Rx" = (/obj/structure/bookcase/random/adult,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Rz" = (/obj/structure/window/reinforced/survival_pod,/obj/effect/turf_decal/siding/dark,/obj/structure/table,/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/west{req_access = list("syndicate")},/obj/effect/spawner/random/food_or_drink/pizzaparty{loot = list(/obj/item/pizzabox/margherita = 2, /obj/item/pizzabox/meat = 2, /obj/item/pizzabox/mushroom = 2, /obj/item/pizzabox/pineapple = 2, /obj/item/pizzabox/vegetable = 2); pixel_y = 9},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"RE" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/conveyor{id = "ds2disposals"},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/spawner/random/trash/garbage{pixel_x = 4; pixel_y = 5},/turf/open/floor/iron/pool,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"RH" = (/obj/effect/turf_decal/siding/dark,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"RP" = (/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"RQ" = (/obj/structure/table/wood,/obj/effect/spawner/random/bureaucracy/folder{pixel_x = 7; pixel_y = 8},/obj/effect/spawner/random/bureaucracy/folder{pixel_x = 4; pixel_y = 3},/obj/item/stamp{pixel_x = -7; pixel_y = 6},/obj/item/stamp/denied{pixel_x = -6},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/machinery/button/door{id = "ds2corpliaison"; req_access = list("syndicate_leader"); name = "Shutters control"; desc = "Keep out the paperwork."; pixel_y = 24; pixel_x = -32},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"RT" = (/obj/effect/turf_decal/tile/dark_blue{dir = 8},/obj/effect/turf_decal/tile/dark_blue{dir = 4},/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/obj/structure/filingcabinet,/obj/item/folder/syndicate/red,/obj/machinery/firealarm/directional/north,/obj/machinery/camera/xray/directional/north{network = list("ds2"); c_tag = "DS-2 Vault"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"RV" = (/obj/effect/turf_decal/stripes/red/corner,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/effect/turf_decal/box/white/corners{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"RX" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"RY" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"RZ" = (/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Sb" = (/obj/machinery/door/firedoor,/obj/structure/cable,/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Sc" = (/obj/effect/turf_decal/siding/wood{dir = 8},/obj/structure/table/wood,/obj/structure/window/reinforced/survival_pod,/obj/item/paper_bin,/obj/structure/window/reinforced/survival_pod{dir = 10},/obj/item/pen,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Se" = (/obj/structure/table,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Sf" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/structure/closet/secure_closet/ds2atmos{anchorable = 0; anchored = 1},/obj/effect/turf_decal/trimline/dark_red/corner,/obj/effect/turf_decal/trimline/dark_red/corner{dir = 8},/obj/machinery/camera/xray/directional/south{network = list("ds2"); c_tag = "DS-2 Bridge"},/obj/structure/extinguisher_cabinet/directional/south,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Si" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Sj" = (/obj/effect/turf_decal/trimline/yellow/corner{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/cold/directional/east,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"So" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_blue/line{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Sp" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/firealarm/directional/west,/obj/structure/rack/gunrack,/obj/item/gun/ballistic/automatic/pistol{pixel_x = -4; pixel_y = 4},/obj/item/gun/ballistic/automatic/pistol{pixel_x = -8},/obj/item/gun/ballistic/automatic/pistol,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
-"Sq" = (/obj/machinery/light/warm/directional/east,/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/components/trinary/filter/flipped,/obj/structure/extinguisher_cabinet/directional/east,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Sv" = (/obj/machinery/autolathe/hacked,/obj/effect/turf_decal/trimline/purple/filled/line,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Sw" = (/obj/effect/turf_decal/siding/wood{dir = 9},/obj/machinery/modular_computer/console/preset/curator,/turf/open/floor/wood/parquet,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Sx" = (/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/structure/cable,/obj/machinery/computer/camera_advanced/syndie,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Sy" = (/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"SB" = (/obj/effect/turf_decal/trimline/purple/filled/corner{dir = 8},/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/dark/corner{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"SG" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 1},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"SH" = (/obj/effect/turf_decal/delivery/red,/obj/machinery/door/firedoor,/obj/effect/turf_decal/stripes/red/line,/obj/effect/turf_decal/stripes/red/line{dir = 1},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"SI" = (/obj/machinery/atmospherics/components/binary/pump/off/supply/visible/layer4{dir = 8},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 8},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 4},/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{dir = 4},/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"SN" = (/obj/machinery/deepfryer,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"SO" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/effect/turf_decal/siding/dark,/turf/open/floor/iron/textured,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"SR" = (/obj/effect/turf_decal/skyrat_decals/syndicate/top/right,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"SX" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/disposalpipe/segment{dir = 9},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"SY" = (/obj/structure/table/wood,/obj/item/storage/photo_album/syndicate{pixel_x = -5; pixel_y = -3},/obj/item/stamp/syndicate{pixel_x = 9; pixel_y = 9},/obj/item/stamp/denied{pixel_x = 11; pixel_y = 3},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 8},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"SZ" = (/obj/machinery/computer/security{dir = 1; network = list("ds2")},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Ta" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/trimline/purple/filled/line{dir = 1},/obj/machinery/light/cold/directional/south,/obj/item/stack/sheet/glass/fifty{pixel_y = 9},/obj/item/stack/sheet/iron/fifty,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Td" = (/obj/structure/window/reinforced/tinted{dir = 1},/obj/machinery/power/shuttle_engine/heater,/obj/structure/window/reinforced/tinted{dir = 8},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"Tf" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/stripes/red/corner,/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/item/trash/boritos/red{pixel_x = -13; pixel_y = -10},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Tm" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/computer/atmos_control/nocontrol/incinerator{dir = 1; atmos_chambers = list("syndieincinerator" = "DS-2 Incinerator Chamber")},/obj/structure/window/reinforced/survival_pod,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"To" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Tp" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Ts" = (/obj/structure/railing{dir = 8},/obj/structure/marker_beacon/burgundy,/obj/structure/railing/corner{dir = 8; pixel_y = 32},/obj/effect/turf_decal/tile/dark_red/half{dir = 1},/obj/effect/turf_decal/siding/wideplating_new/dark{dir = 1},/obj/machinery/light/red/directional/south,/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Tt" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Tu" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/purple/warning{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Tw" = (/obj/effect/turf_decal/siding/dark,/obj/structure/table/glass,/obj/item/grenade/chem_grenade/antiweed{pixel_x = -8; pixel_y = 8},/obj/item/reagent_containers/spray/plantbgone{pixel_x = 11; pixel_y = 11},/obj/item/watertank,/obj/item/clothing/accessory/armband/hydro{desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."; name = "service armband"; pixel_x = 15},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"Tx" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/item/stack/sheet/iron/five,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"TA" = (/obj/machinery/firealarm/directional/east,/obj/machinery/vending/syndichem,/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"TB" = (/obj/docking_port/stationary{dir = 4; dwidth = 5; height = 8; name = "DS-2 Hangar"; width = 11},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"TG" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/effect/turf_decal/trimline/dark_blue/filled/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/chair/sofa/bench/left{dir = 4},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"TH" = (/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 6},/obj/effect/turf_decal/siding/dark{dir = 6},/obj/structure/bed/pod,/obj/item/bedsheet/black,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"TI" = (/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/siding/dark,/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{dir = 4},/obj/machinery/meter,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"TL" = (/obj/item/clothing/suit/hooded/wintercoat/engineering,/obj/item/clothing/head/soft/sec/syndicate,/obj/item/clothing/under/syndicate/skyrat/overalls,/obj/item/clothing/under/syndicate/skyrat/overalls/skirt,/obj/item/clothing/under/rank/engineering/engineer/skyrat/utility/syndicate,/obj/item/clothing/suit/jacket/gorlex_harness,/obj/item/clothing/suit/hazardvest,/obj/structure/closet/secure_closet{icon_state = "eng_secure"; name = "engine technician gear locker"; req_access = list("syndicate")},/obj/item/clothing/accessory/armband/engine{name = "engine technician armband"; desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."},/obj/item/clothing/accessory/armband/engine{name = "engine technician armband"; desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."},/obj/item/clothing/glasses/hud/ar/aviator/meson,/obj/effect/turf_decal/trimline/yellow/filled/line{dir = 8},/obj/effect/turf_decal/trimline/yellow/line{dir = 8},/obj/effect/turf_decal/trimline/yellow/warning{dir = 4},/obj/effect/turf_decal/siding/yellow{dir = 4},/obj/item/holosign_creator/atmos{pixel_y = -8},/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"TM" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/line{dir = 6},/obj/machinery/power/rtg/advanced,/obj/machinery/light/warm/directional/south,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"TQ" = (/obj/item/storage/box/pillbottles{pixel_x = -3; pixel_y = 5},/obj/item/storage/box/gloves{pixel_x = 6; pixel_y = 3},/obj/item/storage/box/medipens{pixel_x = 4; pixel_y = 13},/obj/structure/table/glass,/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"TS" = (/obj/structure/cable,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/door/airlock/vault{id_tag = "syndie_ds2_vault"},/obj/effect/mapping_helpers/airlock/locked,/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"TT" = (/obj/machinery/button/door/directional/west{desc = "To keep your hangar away from prying eyes."; id = "void-be-gone"; name = "Hangar Blast Door Control"; req_access = list("syndicate")},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/firealarm/directional/west,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"TW" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"TX" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"Ua" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/obj/structure/chair/stool/directional/west,/obj/effect/turf_decal/stripes/red/line{dir = 9},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Uc" = (/obj/machinery/light/cold/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/reagent_dispensers/wall/peppertank/directional/west,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Ue" = (/obj/item/reagent_containers/cup/bucket/wooden,/obj/effect/turf_decal/trimline/dark_red/filled/line{dir = 5},/obj/effect/turf_decal/siding/dark{dir = 5},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Uh" = (/obj/effect/turf_decal/siding/wood{dir = 4},/obj/structure/table/wood,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 6},/obj/item/wallframe/painting,/obj/item/wallframe/painting{pixel_x = 4; pixel_y = 4},/obj/item/flashlight/lamp/green{pixel_x = -10},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Ui" = (/obj/structure/table/wood,/obj/item/reagent_containers/cup/rag,/obj/item/storage/fancy/cigarettes/cigpack_syndicate{pixel_y = 6; pixel_x = 3},/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Uj" = (/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/structure/cable,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/airlock/command{name = "Bridge"; hackProof = 1},/obj/effect/mapping_helpers/airlock/unres{dir = 4},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Um" = (/obj/effect/turf_decal/trimline/dark_green/line{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Un" = (/obj/structure/table,/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/machinery/light/warm/directional/east,/obj/item/plate{pixel_x = -4},/obj/effect/spawner/random/food_or_drink/dinner{pixel_x = -4; pixel_y = 4},/obj/effect/spawner/random/food_or_drink/refreshing_beverage{pixel_x = 8; pixel_y = 8},/obj/structure/cable,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Up" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 8},/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_red/line{dir = 4},/obj/effect/turf_decal/trimline/dark_red/line{dir = 8},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 8},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_half{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Us" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"Uv" = (/obj/structure/disposalpipe/trunk{dir = 1},/obj/structure/lattice,/turf/template_noop,/area/template_noop)
-"Uz" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/cold/directional/east,/obj/effect/turf_decal/trimline/dark_blue/corner,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"UB" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/structure/cable,/obj/machinery/door/poddoor/preopen{id = "ds2bridge"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"UE" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/dark_blue/corner{dir = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/light/cold/directional/north,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"UM" = (/obj/structure/table/reinforced,/obj/item/storage/backpack/duffelbag/syndie/surgery{pixel_y = 4},/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/item/clothing/suit/apron/surgical{pixel_x = -4; pixel_y = -5},/obj/item/reagent_containers/spray/cleaner{pixel_x = 7; pixel_y = -9},/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white{dir = 8},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"UO" = (/obj/machinery/door/firedoor,/obj/structure/table/reinforced/plastitaniumglass,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/reagentgrinder{pixel_y = 5},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"UQ" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/preopen{id = "diner-view"},/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"UR" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"UT" = (/obj/effect/turf_decal/siding/wood{dir = 6},/obj/machinery/light/warm/directional/east,/obj/machinery/vending/dorms,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"UX" = (/obj/machinery/door/firedoor,/obj/machinery/door/window/survival_pod{req_access = list("syndicate_leader"); dir = 1},/obj/structure/table/reinforced/plastitaniumglass,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"UY" = (/obj/effect/turf_decal/stripes/line{dir = 5},/obj/structure/cable,/obj/machinery/power/rtg/advanced,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Va" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/effect/turf_decal/stripes/red/corner{dir = 8},/obj/machinery/button/door/directional/south{desc = "Keep out the Officers."; id = "smasteratarms"; name = "Master at Arms' room bolt"; normaldoorcontrol = 1; req_access = list("syndicate_leader"); specialfunctions = 4; pixel_x = 6},/obj/machinery/button/door/directional/south{desc = "Keep out the Officers."; id = "smasteratarms"; name = "Master at Arms' shutters control"; req_access = list("syndicate_leader"); pixel_x = -6},/obj/structure/cable,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Vb" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Ve" = (/obj/machinery/light/cold/directional/south,/obj/machinery/processor,/obj/effect/turf_decal/bot_white,/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Vf" = (/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{dir = 4},/turf/open/floor/engine/o2,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Vm" = (/obj/machinery/light/cold/directional/east,/obj/effect/turf_decal/siding/dark{dir = 6},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Vn" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 5},/obj/effect/turf_decal/trimline/dark_red/line{dir = 5},/obj/effect/turf_decal/trimline/dark_red/corner{dir = 8},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark/textured_corner{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Vo" = (/obj/machinery/light/cold/directional/west,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/bot,/obj/machinery/firealarm/directional/west,/obj/structure/ore_box,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Vp" = (/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Vu" = (/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white,/obj/machinery/chem_mass_spec,/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"Vv" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden{dir = 9},/obj/structure/canister_frame/machine/unfinished_canister_frame,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Vw" = (/obj/machinery/gibber,/obj/machinery/light/cold/directional/south,/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Vy" = (/obj/machinery/door/firedoor,/obj/structure/table/reinforced/plastitaniumglass,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/recharger,/obj/effect/turf_decal/delivery/red,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/item/restraints/handcuffs{pixel_y = -9},/obj/item/crowbar{pixel_y = -13},/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Vz" = (/obj/effect/turf_decal/siding/dark/corner{dir = 8},/obj/structure/disposalpipe/segment{dir = 10},/turf/open/floor/iron/dark/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"VB" = (/obj/machinery/hydroponics/constructable,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"VC" = (/obj/machinery/camera/directional/north{network = list("ds2"); c_tag = "DS-2 Interrogation Room"},/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"VE" = (/obj/effect/turf_decal/trimline/purple/warning{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"VF" = (/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/light/red/directional/south,/obj/item/circuitboard/machine/ore_silo,/obj/structure/frame/machine{anchored = 1; state = 2; icon_state = "box_1"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"VJ" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/template_noop)
-"VK" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/structure/chair{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 5},/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"VM" = (/obj/machinery/light/cold/directional/north,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"VO" = (/obj/structure/weightmachine/weightlifter,/obj/effect/turf_decal/tile/neutral/half/contrasted{dir = 1},/obj/effect/turf_decal/trimline/dark/line{dir = 1},/obj/effect/turf_decal/trimline/dark/line{dir = 1},/obj/machinery/airalarm/syndicate{dir = 1; pixel_y = 24},/turf/open/floor/iron,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"VP" = (/obj/machinery/power/shuttle_engine/large,/obj/effect/turf_decal/stripes/line,/obj/machinery/light/floor{use_power = 0},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"VR" = (/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,/obj/machinery/meter,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"VT" = (/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"VX" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/shutters{name = "Corporate Liaison Shutters"; id = "ds2corpliaison"; dir = 8},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
-"VY" = (/obj/effect/turf_decal/stripes/red/corner,/obj/effect/turf_decal/stripes/red/corner{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/button/door/directional/east{desc = "To keep pesky prisoners obedient."; id = "gaybabyjail"; name = "Isolation Cell Control"; req_access = list("syndicate_leader")},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Wf" = (/obj/effect/turf_decal/bot,/obj/item/storage/toolbox/syndicate{pixel_y = 5},/obj/item/circuitboard/machine/rtg/advanced{pixel_y = -2},/obj/item/circuitboard/machine/rtg/advanced,/obj/item/circuitboard/machine/rtg/advanced{pixel_y = 2},/obj/item/circuitboard/machine/rtg/advanced{pixel_y = 5},/obj/effect/spawner/random/techstorage/data_disk{pixel_x = -5},/obj/item/storage/box/stockparts/deluxe{pixel_y = -4; pixel_x = 3},/obj/structure/closet/crate/engineering,/obj/item/t_scanner,/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = -3},/obj/machinery/airalarm/syndicate{pixel_y = -24},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Wk" = (/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{dir = 4},/turf/open/floor/engine/plasma,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Wm" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/trimline/brown/warning{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Wn" = (/obj/effect/turf_decal/siding/wood{dir = 9},/obj/structure/chair/sofa/corp/right{color = "#DE3A3A"},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Wq" = (/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Ws" = (/obj/machinery/firealarm/directional/west,/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{dir = 4},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Wt" = (/obj/structure/bed,/obj/item/bedsheet/medical,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Wu" = (/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,/obj/effect/turf_decal/delivery/red,/obj/machinery/door/airlock/security/old/glass{name = "Long-Term Brig"},/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/machinery/door/firedoor,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{cycle_id = "DS2permabrig"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Wv" = (/obj/effect/turf_decal/stripes/red/line{dir = 4},/obj/effect/turf_decal/stripes/red/line{dir = 8},/obj/effect/turf_decal/delivery/red,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/door/window/survival_pod{req_access = list("syndicate_leader"); dir = 8; name = "Isolation Cell"},/obj/machinery/door/window/survival_pod{req_access = list("syndicate_leader"); dir = 4; name = "Isolation Cell"},/obj/machinery/door/poddoor/preopen{id = "gaybabyjail"},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Ww" = (/obj/effect/turf_decal/box/red/corners{dir = 8},/obj/effect/turf_decal/stripes/red/corner{dir = 4},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
-"Wx" = (/obj/machinery/light/warm/directional/west,/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/siding/dark{dir = 8},/obj/structure/sign/warning/no_smoking/directional/west,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Wz" = (/obj/effect/turf_decal/trimline/purple/filled/line,/obj/effect/turf_decal/siding/dark/corner{dir = 1},/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/airalarm/syndicate{pixel_y = -24},/turf/open/floor/iron/dark/side,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"WA" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/effect/turf_decal/siding/wood/corner,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"WC" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/catwalk_floor/iron_dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"WE" = (/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,/obj/machinery/door/poddoor/preopen{id = "dorms-view"},/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"WG" = (/obj/effect/turf_decal/siding/dark/corner,/obj/effect/turf_decal/siding/dark/corner{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"WH" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"WL" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{dir = 4},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"WM" = (/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{dir = 10},/obj/effect/turf_decal/siding/thinplating/dark{dir = 8},/obj/effect/turf_decal/vg_decals/atmos/air,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"WN" = (/obj/effect/turf_decal/siding/thinplating/dark,/obj/effect/turf_decal/trimline/dark_red/corner{dir = 8},/obj/effect/turf_decal/trimline/dark_red/line{dir = 5},/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/structure/cable,/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/obj/item/paper_bin{pixel_x = -2; pixel_y = 5},/obj/item/pen{pixel_y = 5; pixel_x = -2},/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"WS" = (/obj/effect/turf_decal/stripes/red/line{dir = 1},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"WW" = (/obj/effect/turf_decal/siding/dark/corner{dir = 4},/obj/effect/turf_decal/siding/dark/corner,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"WZ" = (/obj/effect/turf_decal/siding/yellow{dir = 4},/obj/effect/turf_decal/trimline/yellow/filled/line{dir = 8},/obj/effect/turf_decal/trimline/yellow/warning{dir = 4},/obj/effect/turf_decal/trimline/yellow/line{dir = 8},/obj/structure/closet/secure_closet{icon_state = "eng"; name = "electrical supplies locker"; req_access = list("syndicate"); icon_door = "eng_elec"},/obj/item/electronics/airlock{pixel_y = -7; pixel_x = 5},/obj/item/electronics/airlock{pixel_y = -7; pixel_x = -5},/obj/item/storage/toolbox/electrical{pixel_y = -7},/obj/item/electronics/apc{pixel_x = 4; pixel_y = 5},/obj/item/electronics/firelock{pixel_y = 5; pixel_x = -6},/obj/item/electronics/airalarm{pixel_x = 2},/obj/item/stock_parts/cell/high{pixel_y = -8; pixel_x = -8},/obj/item/stock_parts/cell/high{pixel_y = -8; pixel_x = -4},/obj/item/stock_parts/cell/high{pixel_y = -8},/obj/item/stock_parts/cell/high{pixel_y = -8; pixel_x = 4},/obj/item/stock_parts/cell/high{pixel_y = -8; pixel_x = 8},/obj/item/clothing/glasses/meson/engine,/turf/open/floor/iron/dark/side{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Xb" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Xf" = (/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{dir = 4},/obj/machinery/atmospherics/pipe/smart/simple/green/hidden/layer2{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/siding/dark,/obj/effect/turf_decal/siding/dark{dir = 1},/obj/machinery/door/airlock/hatch{name = "Incinerator Hatch"; id_tag = "DS2incineratorHatch"},/obj/effect/mapping_helpers/airlock/locked,/obj/structure/holosign/barrier/atmos/sturdy,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Xg" = (/obj/effect/turf_decal/stripes/red/line,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Xh" = (/turf/closed/wall/r_wall/syndicate/nodiagonal,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"Xk" = (/obj/effect/turf_decal/siding/wood{dir = 8},/obj/structure/bookcase/random/fiction,/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
-"Xl" = (/obj/machinery/vending/imported/yangyu,/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Xm" = (/obj/structure/chair,/obj/machinery/airalarm/syndicate{dir = 8; pixel_x = -24},/obj/effect/turf_decal/siding/dark{dir = 1},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"Xn" = (/obj/structure/table/reinforced,/obj/item/grenade/chem_grenade/smart_metal_foam{pixel_y = 8},/obj/item/grenade/chem_grenade/smart_metal_foam{pixel_x = 4; pixel_y = 5},/obj/item/grenade/chem_grenade/smart_metal_foam{pixel_x = -5; pixel_y = 4},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"Xq" = (/obj/effect/turf_decal/trimline/yellow/line,/obj/structure/disposalpipe/segment{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Xr" = (/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating/end{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/disposalpipe/trunk{dir = 4},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Xt" = (/obj/machinery/conveyor{dir = 4; id = "ds2conveyor"},/obj/machinery/light/red/directional/south,/obj/structure/plasticflaps,/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Xy" = (/obj/structure/cable,/obj/structure/disposalpipe/segment{dir = 5},/turf/open/floor/iron/kitchen{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Xz" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/vending/hydronutrients,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"XA" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/yellow{dir = 10},/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/enginetech{dir = 8},/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"XC" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/closet/crate/solarpanel_small,/obj/effect/turf_decal/tile/brown/half{dir = 1},/turf/open/floor/iron/dark/textured_half{dir = 4},/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"XF" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/segment{dir = 9},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"XG" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
-"XI" = (/obj/effect/turf_decal/siding/wood{dir = 8},/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/south{req_access = list("syndicate")},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"XN" = (/obj/effect/turf_decal/siding/thinplating/dark,/obj/effect/turf_decal/trimline/dark_red/line,/obj/effect/turf_decal/trimline/dark_red/line{dir = 1},/obj/effect/turf_decal/trimline/dark_red/mid_joiner,/obj/effect/turf_decal/trimline/dark_red/mid_joiner{dir = 1},/obj/machinery/computer/monitor{dir = 4},/obj/structure/cable,/obj/machinery/power/apc/auto_name/directional/north{req_access = list("syndicate")},/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"XP" = (/obj/structure/window/reinforced/tinted{dir = 1},/obj/machinery/power/shuttle_engine/heater,/obj/structure/window/reinforced/tinted{dir = 4},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"XR" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 4},/obj/machinery/light/cold/directional/west,/obj/structure/disposalpipe/junction/flip{dir = 2},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"XV" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/machinery/firealarm/directional/north,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"XX" = (/obj/structure/railing{dir = 8},/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"XY" = (/obj/machinery/chem_dispenser/mutagensaltpeter,/obj/machinery/power/apc/auto_name/directional/west{req_access = list("syndicate")},/obj/structure/cable,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
-"Ya" = (/obj/effect/turf_decal/siding/thinplating/dark{dir = 1},/obj/effect/turf_decal/trimline/dark_red/line,/obj/structure/sign/flag/syndicate/directional/south{pixel_x = -16},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/coffeemaker,/turf/open/floor/iron/dark/textured_half,/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"Yb" = (/obj/effect/turf_decal/stripes/line,/obj/machinery/light/floor{use_power = 0},/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
-"Yd" = (/obj/machinery/power/turbine/turbine_outlet,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/siding/dark,/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"Ye" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/item/paper_bin{pixel_y = 4},/obj/item/pen{pixel_y = 4},/obj/item/flashlight/lamp{pixel_x = -6},/obj/structure/table/wood,/obj/effect/turf_decal/siding/wood{dir = 4},/turf/open/floor/wood,/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
-"Yn" = (/obj/effect/turf_decal/trimline/dark_green/line{dir = 4},/obj/structure/disposalpipe/segment{dir = 2},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Yp" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Yz" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 4},/obj/machinery/light/warm/directional/west,/obj/machinery/skill_station,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"YC" = (/obj/machinery/air_sensor{chamber_id = "syndieincinerator"},/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{dir = 4},/obj/machinery/atmospherics/pipe/smart/simple/green/hidden/layer2{dir = 9},/turf/open/floor/engine,/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
-"YD" = (/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"YG" = (/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/admiral,/turf/open/floor/carpet/red,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"YH" = (/obj/machinery/door/airlock/silver{name = "Public Showers"},/obj/machinery/door/firedoor,/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"YI" = (/obj/effect/turf_decal/stripes/red/corner{dir = 8},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/skyrat/interdynefob/security)
-"YK" = (/obj/item/circuitboard/computer/mech_bay_power_console,/obj/effect/turf_decal/trimline/dark_red/filled/line,/obj/structure/frame/computer,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"YN" = (/obj/machinery/vending/wardrobe/syndie_wardrobe,/turf/open/floor/iron/dark/smooth_large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"YQ" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"YR" = (/obj/structure/table,/obj/effect/turf_decal/trimline/purple/filled/line{dir = 4},/obj/machinery/camera/xray/directional/west{network = list("ds2"); c_tag = "DS-2 Research"},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/research)
-"Zd" = (/obj/machinery/disposal/bin,/obj/effect/turf_decal/siding/thinplating/end{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/disposalpipe/trunk{dir = 8},/turf/open/floor/iron/small,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Zg" = (/obj/machinery/suit_storage_unit/syndicate/softsuit,/turf/open/floor/iron/dark/small,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
-"Zh" = (/obj/machinery/conveyor{dir = 4; id = "ds2conveyor"},/obj/machinery/door/poddoor{id = "ds2cargo"},/turf/open/floor/plating,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Zi" = (/obj/effect/turf_decal/trimline/purple/corner,/obj/structure/disposalpipe/segment{dir = 2},/obj/machinery/door/firedoor,/obj/effect/turf_decal/delivery,/turf/open/floor/iron/dark/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"Zo" = (/obj/effect/turf_decal/tile/yellow,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"Zp" = (/obj/machinery/iv_drip,/obj/machinery/duct,/turf/open/floor/iron/showroomfloor,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Zq" = (/obj/structure/sign/flag/syndicate/directional/south,/obj/machinery/light/warm/directional/south,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
-"Zs" = (/obj/item/bedsheet/medical,/obj/structure/bed,/turf/open/floor/iron/white/small,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"Zt" = (/obj/effect/turf_decal/tile/bar/opposingcorners{dir = 8},/obj/structure/table,/obj/effect/spawner/random/food_or_drink/refreshing_beverage{pixel_x = -7; pixel_y = 8},/obj/effect/spawner/random/food_or_drink/salad{pixel_y = 3},/obj/machinery/light/warm/directional/north,/turf/open/floor/iron/cafeteria,/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
-"Zz" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/grunge{id_tag = "TESRedguard"; name = "Dormitory"},/obj/effect/mapping_helpers/airlock/cutaiwire,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/turf/open/floor/wood/tile,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"ZA" = (/obj/effect/turf_decal/siding/thinplating/dark/corner{dir = 1},/obj/structure/table/reinforced/plastitaniumglass,/obj/effect/turf_decal/trimline/dark_red/line{dir = 8},/obj/effect/turf_decal/trimline/dark_red/line{dir = 6},/obj/item/toy/mecha/mauler{pixel_y = 16},/obj/item/toy/mecha/deathripley{pixel_x = -16; pixel_y = 8},/obj/item/toy/figure/syndie,/turf/open/floor/iron/dark/smooth_corner{dir = 1},/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
-"ZB" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"ZC" = (/obj/effect/turf_decal/stripes/red/line,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/structure/disposalpipe/junction{dir = 4},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/halls)
-"ZE" = (/obj/effect/turf_decal/siding/dark{dir = 4},/obj/machinery/light/red/directional/west,/obj/machinery/turretid{ailock = 1; control_area = "/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault"; dir = 1; icon_state = "control_kill"; lethal = 1; name = "DS2 turret controls"; req_access = list("syndicate"); pixel_x = -30},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
-"ZF" = (/obj/structure/table,/obj/structure/bedsheetbin,/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/obj/effect/turf_decal/tile/neutral{dir = 4},/obj/effect/turf_decal/trimline/dark/corner{dir = 4},/obj/effect/turf_decal/trimline/dark/corner{dir = 4},/turf/open/floor/iron/dark/side{dir = 8},/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
-"ZH" = (/obj/structure/window/reinforced/survival_pod{dir = 4; pixel_x = 4},/obj/machinery/smartfridge/organ,/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white/corner{dir = 8},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
-"ZP" = (/obj/effect/turf_decal/siding/wood{dir = 6},/obj/item/kirbyplants{icon_state = "plant-22"},/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/wood/large,/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
-"ZQ" = (/obj/structure/cable,/obj/effect/turf_decal/trimline/brown/warning{dir = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
-"ZS" = (/obj/machinery/chem_dispenser/fullupgrade,/obj/effect/turf_decal/tile/dark_blue/full,/obj/effect/turf_decal/siding/white{dir = 1},/turf/open/floor/iron/white/textured_large,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"ZT" = (/obj/effect/turf_decal/siding/dark{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron/white,/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
-"ZY" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plating/airless,/area/ruin/space/has_grav/skyrat/interdynefob)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/light/cold/directional/west,
+/obj/structure/closet/secure_closet{
+	name = "prisoner item locker";
+	req_access = list("syndicate_leader")
+	},
+/obj/machinery/power/apc/auto_name/directional/west{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ab" = (
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/hostile/retaliate/tegu{
+	name = "Entertains-The-Hostages"
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ac" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet{
+	name = "MODsuit module locker";
+	req_access = list("syndicate_leader");
+	icon_state = "syndicate"
+	},
+/obj/item/mod/module/stealth,
+/obj/item/mod/module/projectile_dampener{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/mod/module/pepper_shoulders,
+/obj/item/mod/module/criminalcapture{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/obj/item/mod/module/visor/night,
+/obj/item/screwdriver/nuke{
+	pixel_y = -2
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"ad" = (
+/obj/machinery/telecomms/relay/preset/mining,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"ae" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/structure/closet/crate/cardboard,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"af" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/structure/cable,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/cat/kitten{
+	desc = "What appears to be a single-celled organism with a pronounced low-level intelligence.";
+	name = "Murder-Mittens"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"ag" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"ah" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"aj" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/mech_recharger,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"ak" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	hackProof = 1;
+	id_tag = "scorpliaison";
+	name = "Corporate Liaison"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"ao" = (
+/obj/machinery/stasis,
+/obj/machinery/camera/xray/directional/south{
+	network = list("ds2");
+	c_tag = "DS-2 Medical"
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"at" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"au" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"av" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera/xray/directional/north{
+	network = list("ds2");
+	c_tag = "DS-2 Isolation Cell"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ax" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "ds2conveyor"
+	},
+/obj/structure/railing,
+/obj/machinery/light/red/directional/north,
+/obj/structure/plasticflaps,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"az" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"aB" = (
+/obj/machinery/vending/imported/tizirian,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"aC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"aF" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"aH" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"aJ" = (
+/obj/effect/turf_decal/vg_decals/numbers/one{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/template_noop)
+"aL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"aN" = (
+/obj/machinery/atmospherics/components/binary/valve/digital,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"aP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	req_access = list("syndicate")
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"aR" = (
+/obj/effect/turf_decal/trimline/dark_green/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"aT" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"aW" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 6
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"aX" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"aY" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/recharger,
+/obj/item/paper_bin{
+	pixel_x = -14
+	},
+/obj/item/pen{
+	pixel_x = -14
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"aZ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"ba" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"bd" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"be" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	volume_rate = 200
+	},
+/turf/template_noop,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"bj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/chair/office,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"bk" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/door{
+	id = "ds2armory";
+	req_access = list("syndicate_leader");
+	name = "Armory Access";
+	desc = "To keep your valuable gear away from prying eyes.";
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"bn" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/power/shuttle_engine/heater,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"bo" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"bq" = (
+/obj/item/storage/belt/security/full,
+/obj/item/radio/headset/interdyne,
+/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,
+/obj/item/storage/belt/security/webbing/ds,
+/obj/item/clothing/head/beret/sec/syndicate,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/item/clothing/accessory/armband{
+	name = "brig officer armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "brig officer gear locker";
+	req_access = list("syndicate_leader")
+	},
+/obj/item/clothing/mask/gas/syndicate/ds,
+/obj/item/clothing/suit/toggle/jacket/sec/old{
+	name = "brig officer jacket"
+	},
+/obj/item/clothing/mask/gas/sechailer/syndicate,
+/obj/item/gun/energy/disabler,
+/obj/item/clothing/glasses/hud/security/sunglasses/eyepatch/redsec,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"bs" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"bt" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/syndie{
+	name = "station admiral's bedsheet";
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"bu" = (
+/obj/structure/curtain,
+/obj/structure/drain,
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"bw" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"bx" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/curtain{
+	id = "DS2cell2";
+	name = "curtain control";
+	pixel_y = 24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"by" = (
+/obj/machinery/vending/security{
+	name = "\improper Stolen Armadyne Equipment Vendor";
+	desc = "An Armadyne peacekeeper equipment vendor. Makes you wonder why there's no Gorlex Equipment Vendor yet."
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"bA" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"bP" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_y = 3
+	},
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"bR" = (
+/obj/machinery/computer/operating,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"bS" = (
+/obj/item/melee/baton/telescopic{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/melee/baton/telescopic{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/melee/baton/telescopic{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/melee/energy/sword/saber/red,
+/obj/item/melee/energy/sword/saber/red{
+	pixel_x = 13
+	},
+/obj/item/melee/energy/sword/saber/red{
+	pixel_x = 7
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/rack/shelf,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"bW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"bX" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/item/paper,
+/obj/item/pen{
+	pixel_y = 3;
+	pixel_x = -5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"bY" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"ca" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"cb" = (
+/obj/item/clothing/shoes/galoshes{
+	pixel_y = -8
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/holosign_creator/janibarrier{
+	pixel_y = -9
+	},
+/obj/item/mop,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/mop_bucket/janitorialcart{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"ch" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera/xray/directional/north{
+	network = list("ds2");
+	c_tag = "DS-2 Diner"
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"cj" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/middle/middle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/skyrat_decals/ds2/middle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"cm" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/transit_tube{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ds2bridge"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"cn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"cq" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/machinery/button/door/directional/east{
+	desc = "To keep your hangar away from prying eyes.";
+	id = "void-be-gone";
+	name = "Hangar Blast Door Control";
+	req_access = list("syndicate")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/dark_red,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"cr" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"ct" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"cu" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/door/airlock/freezer{
+	name = "Medical Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"cy" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"cz" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"cA" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"cD" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"cE" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/fishing_portal_generator,
+/obj/item/storage/toolbox/fishing,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"cG" = (
+/obj/item/bedsheet/qm{
+	name = "corporate liaison's bedsheet";
+	desc = "It is decorated with the Donk Co. logo."
+	},
+/obj/structure/bed,
+/turf/open/floor/carpet/donk,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"cI" = (
+/obj/machinery/power/shuttle_engine/propulsion/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/floor{
+	use_power = 0
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"cL" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Interrogation Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"cO" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/east{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/obj/machinery/cell_charger_multi,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"cP" = (
+/obj/effect/turf_decal/trimline/blue/corner,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"cS" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"cU" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"cW" = (
+/obj/item/gun/energy/recharge/kinetic_accelerator,
+/obj/item/storage/bag/ore,
+/obj/item/mining_scanner,
+/obj/structure/closet/secure_closet{
+	icon_state = "mining";
+	req_access = list("syndicate");
+	name = "mining gear locker"
+	},
+/obj/item/storage/belt/mining/alt,
+/obj/item/clothing/under/syndicate/skyrat/overalls{
+	pixel_y = -2
+	},
+/obj/item/storage/backpack/satchel/explorer,
+/obj/item/storage/backpack/explorer,
+/obj/item/clothing/accessory/armband/cargo{
+	name = "mining officer armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"cY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"da" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/hedge,
+/obj/machinery/light/warm/directional/north,
+/obj/structure/sign/painting/library{
+	pixel_y = 30
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"dg" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"dh" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"dn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"do" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"dr" = (
+/obj/structure/cable,
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/item/assembly/igniter,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"ds" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"dv" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	color = "#555555";
+	icon_state = "bathroom-open";
+	id = "DS2cell2";
+	icon_type = "bathroom"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"dy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"dz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"dC" = (
+/obj/structure/dresser,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/donk,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"dD" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/dark_red/end,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"dF" = (
+/obj/machinery/button/door/directional/north{
+	desc = "Keep out the riff-raff.";
+	id = "sadmiral";
+	name = "Admiral's room bolt";
+	normaldoorcontrol = 1;
+	req_access = list("syndicate_leader");
+	specialfunctions = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/warm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/bed/dogbed,
+/obj/effect/decal/cleanable/oil,
+/mob/living/basic/pet/syndifox,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"dI" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"dN" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/ds2atmos{
+	anchorable = 0;
+	anchored = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"dO" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"dQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock/command{
+	hackProof = 1;
+	id_tag = "sadmiral";
+	name = "Station Admiral"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"dR" = (
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/structure/drain,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"dS" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"dT" = (
+/obj/machinery/power/shuttle_engine/propulsion/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"dZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"ee" = (
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/storage/fancy/egg_box,
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"ek" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/hedge,
+/obj/structure/sign/painting/library{
+	pixel_y = 30
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"em" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"eo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/obj/item/clothing/under/misc/syndicate_souvenir{
+	has_sensor = 0;
+	pixel_y = -4
+	},
+/obj/item/clothing/under/misc/syndicate_souvenir{
+	has_sensor = 0;
+	pixel_y = -7;
+	pixel_x = 4
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"ep" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/bot_blue,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"ez" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/south{
+	desc = "Keep out the Blazing heat.";
+	id = "DS2incineratorHatch";
+	name = "Incinerator Hatch Bolt";
+	normaldoorcontrol = 1;
+	req_access = list("syndicate_leader");
+	specialfunctions = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"eA" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"eD" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/structure/sign/flag/syndicate/directional/south{
+	pixel_x = 16
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/item/toy/mecha/darkgygax{
+	pixel_y = 16
+	},
+/obj/item/toy/figure/syndie,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"eE" = (
+/obj/structure/filingcabinet,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"eF" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"eH" = (
+/obj/effect/turf_decal/box/red/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"eJ" = (
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"eK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plastitanium,
+/obj/item/stack/sheet/plastitaniumglass,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"eO" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/camera/xray/directional/east{
+	network = list("ds2");
+	c_tag = "DS-2 Botany"
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"eP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"eT" = (
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_y = 10
+	},
+/obj/item/pipe_dispenser{
+	pixel_x = -3
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"eU" = (
+/obj/machinery/light/warm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"eW" = (
+/obj/machinery/button/door{
+	id = "TESRedguard";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	specialfunctions = 4;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"eX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"eY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"fa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"fc" = (
+/obj/effect/turf_decal/box/red/corners{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"fd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/simple_animal/bot/medbot/stationary{
+	radio_channel = "Syndicate";
+	faction = list("Syndicate");
+	maints_access_required = list("syndicate");
+	name = "Insurgent Care"
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"fe" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ff" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"fh" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"fl" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"fo" = (
+/obj/structure/closet/emcloset,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"fw" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/chair/office/light,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"fy" = (
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/chair/stool/directional/north,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"fz" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"fA" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"fB" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"fE" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
+	},
+/obj/structure/sign/flag/syndicate/directional/north,
+/obj/structure/showcase/cyborg{
+	icon = 'icons/mob/silicon/robots.dmi';
+	icon_state = "synd_sec";
+	name = "syndicate cyborg showcase";
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 8;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"fQ" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"fS" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"fW" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"gb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"gg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass{
+	name = "External Access"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"gi" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/vg_decals/numbers/two,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"gj" = (
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/old{
+	hackProof = 1;
+	name = "Long-Term Brig"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "DS2permabrig"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"gk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"gn" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"go" = (
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"gv" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"gw" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/component_printer,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"gx" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"gy" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/teargas{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_y = 3
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"gA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"gB" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/syndicate{
+	pixel_y = -24
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"gF" = (
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "DS2brig"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"gG" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/machinery/camera/xray/directional/north{
+	network = list("ds2");
+	c_tag = "DS-2 Hangar Airlock"
+	},
+/obj/structure/sign/flag/syndicate/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"gK" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"gN" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input{
+	dir = 8;
+	chamber_id = "syndicatelava_incinerator"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"gO" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"gW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"ha" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"he" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/machinery/light/warm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"hf" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"hg" = (
+/obj/machinery/suit_storage_unit/syndicate/softsuit,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"hh" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"hi" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"hn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"ho" = (
+/obj/machinery/computer/security{
+	network = list("ds2");
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"hq" = (
+/obj/structure/drain,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/duct,
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"hs" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"hx" = (
+/obj/machinery/power/turbine/inlet_compressor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"hy" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"hz" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"hA" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/east,
+/obj/effect/spawner/random/contraband/prison,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/random/trash/food_packaging{
+	pixel_y = -5
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"hC" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/rack,
+/obj/item/storage/medkit/emergency,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"hE" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"hF" = (
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"hG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"hH" = (
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"hJ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/hedge,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"hM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "void-be-gone"
+	},
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"hP" = (
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"hQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/cardboard,
+/obj/item/pai_card,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"hR" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"hT" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"hZ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"ib" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/chem_heater/withbuffer,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"ie" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos{
+	name = "master at arms's bedsheet"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"ih" = (
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"ij" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/circuit_imprinter,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"il" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"io" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"it" = (
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"iw" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/freezer{
+	name = "imported ingredient freezer"
+	},
+/obj/item/reagent_containers/condiment/vinegar{
+	pixel_x = -3;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/condiment/yoghurt{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/condiment/cornmeal{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/food/canned_jellyfish{
+	pixel_x = 5
+	},
+/obj/item/food/desert_snails{
+	pixel_y = 1;
+	pixel_x = -3
+	},
+/obj/item/food/canned/tomatoes,
+/obj/item/food/canned/tuna{
+	pixel_y = -5;
+	pixel_x = -6
+	},
+/obj/item/food/canned/pine_nuts{
+	pixel_y = -9;
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/condiment/quality_oil{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/food/fishmeat/moonfish{
+	pixel_y = -11
+	},
+/obj/item/food/fishmeat/moonfish{
+	pixel_y = -8
+	},
+/obj/item/food/fishmeat/moonfish{
+	pixel_y = -5
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"ix" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/item/storage/box/stockparts/basic{
+	pixel_y = 6
+	},
+/obj/item/storage/box/stockparts/basic{
+	pixel_x = 8
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"iy" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"iz" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"iB" = (
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"iE" = (
+/obj/structure/lattice,
+/obj/structure/transit_tube{
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"iF" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"iK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESArena";
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"iM" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"iO" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"iP" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"iR" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"iS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/green/hidden{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"iV" = (
+/obj/item/chair{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"iX" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"iY" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"iZ" = (
+/obj/machinery/light/warm/directional/south,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"jb" = (
+/obj/machinery/iv_drip,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"jc" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"jd" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/item/bodybag/environmental/prisoner/syndicate{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/obj/item/bodybag/environmental/prisoner/syndicate{
+	pixel_x = 7;
+	pixel_y = 15
+	},
+/obj/item/bodybag/environmental/prisoner/syndicate{
+	pixel_y = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/west{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/obj/machinery/camera/xray/directional/west{
+	network = list("ds2");
+	c_tag = "DS-2 Brig Storage"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"jf" = (
+/obj/structure/closet/emcloset,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"jj" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"jl" = (
+/obj/effect/turf_decal/trimline/purple/filled/end{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/coffeemaker,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"jm" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"jp" = (
+/obj/machinery/light/warm/directional/north,
+/obj/machinery/computer{
+	name = "syndicate access change console";
+	icon_keyboard = "syndie_key";
+	icon_screen = "explosive";
+	desc = "A console meant to allow modifications to IDs. There's a chameleon ID stuck inside and no one has been able to pull it out..."
+	},
+/obj/item/paper{
+	default_raw_text = "<h1>DS2 Corporate Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>The Sothran Syndicate welcomes you onboard, Corporate Liaison. It is deeply suggested you help our crew via informing them of their corporate investors' goal and to help maintain cohesion. Don't hurt yourself now, and stay winning.</p>";
+	name = "paper- 'DS2 Corporate Report'"
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"jr" = (
+/obj/item/sign/flag/syndicate{
+	pixel_y = 6;
+	pixel_x = 3
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"jt" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/hedge,
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/light/warm/directional/south,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"jw" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"jB" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479"
+	},
+/obj/machinery/button/door{
+	id = "ds2admiral";
+	req_access = list("syndicate_leader");
+	name = "Shutters control";
+	desc = "Keep out the paperwork.";
+	pixel_y = 24;
+	pixel_x = 32
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"jC" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/middle/right,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/skyrat_decals/ds2/right,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"jD" = (
+/obj/item/storage/secure/briefcase/white{
+	pixel_y = 13
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"jE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/item/toy/figure/syndie{
+	pixel_y = 20;
+	pixel_x = 10
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"jJ" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/mechfab,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"jN" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"jO" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"jP" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"jR" = (
+/obj/effect/turf_decal/box/red/corners,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"jT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"jW" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "science";
+	name = "roboticist gear locker";
+	req_access = list("syndicate")
+	},
+/obj/item/clothing/suit/hooded/techpriest,
+/obj/item/clothing/suit/hooded/wintercoat/robotics,
+/obj/item/clothing/suit/toggle/labcoat/roboticist{
+	pixel_y = 3
+	},
+/obj/item/clothing/under/syndicate/skyrat/overalls/skirt,
+/obj/item/clothing/under/syndicate/skyrat/overalls{
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/hud/ar/aviator/diagnostic,
+/obj/item/clothing/glasses/hud/diagnostic,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"jZ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ka" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"kb" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"kc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"kd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	mapping_id = "syndicatelava_turbine"
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/obj/machinery/button/door/incinerator_vent_syndicatelava_aux{
+	pixel_y = -6;
+	pixel_x = -24;
+	name = "Combustion Chamber Blast Door Control"
+	},
+/obj/machinery/button/door/incinerator_vent_syndicatelava_main{
+	pixel_x = -24;
+	pixel_y = 6;
+	name = "Turbine Exterior Vent Control"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/ignition/incinerator/syndicatelava{
+	pixel_x = -36
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"ke" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"kf" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"kg" = (
+/obj/structure/transit_tube/crossing/horizontal,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"km" = (
+/obj/machinery/button/door{
+	id = "TESBattlespire";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	specialfunctions = 4;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"kt" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"kx" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"kD" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"kF" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"kG" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 2
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"kH" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/vending/medical/syndicate_access/cybersun{
+	desc = "An advanced vendor that dispenses medical drugs, both recreational and medicinal. It's said to have been salvaged from an old decomissioned Cybersun Cruiser.";
+	name = "\improper SyndiMed ++"
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"kI" = (
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 4
+	},
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"kM" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"kN" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/survival_pod{
+	dir = 4;
+	req_access = list("syndicate_leader")
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	heat_proof = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	name = "Corporate Liaison Shutters";
+	id = "ds2corpliaison";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"kQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"kT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"kZ" = (
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"lb" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ld" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"lg" = (
+/obj/item/card/id/advanced/chameleon/black,
+/obj/item/card/id/advanced/chameleon/black,
+/obj/item/card/id/advanced/chameleon/black,
+/obj/structure/closet/secure_closet{
+	icon_state = "hop";
+	name = "\proper corporate liaison's locker";
+	req_access = list("syndicate_leader")
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/item/language_manual/codespeak_manual/unlimited,
+/obj/item/clothing/under/syndicate/skyrat/baseball,
+/obj/item/clothing/under/rank/captain/skyrat/utility/syndicate,
+/obj/item/clothing/under/suit/skyrat/helltaker{
+	has_sensor = 0;
+	random_sensor = 0
+	},
+/obj/item/clothing/neck/chaplain/black{
+	desc = "An unique cloak that shimmers with the Corporate Liaison's emblem.";
+	name = "corporate liaison's cloak"
+	},
+/obj/item/binoculars,
+/obj/item/radio/headset/interdyne/command,
+/obj/item/clothing/head/hos/beret/syndicate,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/encryptionkey/headset_syndicate/interdyne,
+/obj/item/encryptionkey/headset_syndicate/interdyne,
+/obj/item/encryptionkey/headset_syndicate/interdyne,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"li" = (
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/item/stack/medical/gauze{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/stack/medical/mesh{
+	pixel_x = 4
+	},
+/obj/item/stack/medical/suture,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"lo" = (
+/obj/machinery/button/door{
+	id = "syndie_ds2_vault";
+	name = "Vault Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access = list("syndicate");
+	specialfunctions = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"lp" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"lt" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/item/wirecutters,
+/obj/machinery/syndicatebomb/training,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"lu" = (
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"lD" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"lE" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = list("syndicate")
+	},
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/storage/fancy/egg_box,
+/obj/effect/turf_decal/bot_blue,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"lF" = (
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/table,
+/obj/item/mmi/posibrain{
+	pixel_y = 6;
+	pixel_x = 2
+	},
+/obj/item/mmi/posibrain{
+	pixel_x = -4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"lI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light/red/directional/south,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"lJ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/cold/directional/west,
+/obj/item/clothing/shoes/sneakers/crimson{
+	pixel_x = -4
+	},
+/obj/item/clothing/shoes/sneakers/crimson{
+	pixel_x = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/item/clothing/under/rank/prisoner/syndicate,
+/obj/item/clothing/under/rank/prisoner/syndicate{
+	pixel_y = 4
+	},
+/obj/item/clothing/under/rank/prisoner/syndicate{
+	pixel_y = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"lO" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"lU" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"lW" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"lY" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"lZ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/smes,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"md" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/cmo/glass{
+	name = "Medical Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"me" = (
+/obj/machinery/button/door{
+	id = "TESSkyrim";
+	name = "Restroom Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	specialfunctions = 4;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"mg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 8;
+	name = "plasma mixer";
+	target_pressure = 2000
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"mi" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"mj" = (
+/obj/machinery/photocopier,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"ml" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/obj/machinery/door/airlock/external/glass{
+	name = "External Access"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"mr" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"ms" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"mx" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"my" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"mA" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"mC" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering{
+	input_level = 150000;
+	charge = 4.5e+006
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/item/aicard/aitater{
+	pixel_y = 11;
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"mD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"mH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/door/window/survival_pod{
+	req_access = list("syndicate_leader");
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/item/folder/red,
+/obj/item/paper{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/item/paper{
+	pixel_y = -6;
+	pixel_x = 4
+	},
+/obj/item/pen{
+	pixel_y = -4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"mJ" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"mK" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/survival_pod,
+/obj/item/storage/bag/books,
+/obj/item/storage/book/bible/syndicate{
+	pixel_x = -13
+	},
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"mO" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"mP" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"mQ" = (
+/obj/effect/turf_decal/box/red/corners{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"mT" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table/glass,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"mX" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"mY" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"nd" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"ni" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"nm" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"nn" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"ny" = (
+/obj/machinery/light/warm/directional/south,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"nz" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/duct,
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"nA" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/item/storage/box/stockparts/basic{
+	pixel_y = 11;
+	pixel_x = -3
+	},
+/obj/item/storage/box/stockparts/basic{
+	pixel_y = 8;
+	pixel_x = 5
+	},
+/obj/item/storage/box/stockparts/basic,
+/obj/item/storage/part_replacer{
+	pixel_y = -12;
+	pixel_x = -2
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"nG" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/rack/shelf,
+/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_researcher{
+	pixel_y = -6
+	},
+/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_digger{
+	pixel_y = -3
+	},
+/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_recoverer,
+/obj/item/circuitboard/machine/xenoarch_machine/xenoarch_scanner{
+	pixel_y = 3
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"nH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"nI" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"nK" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/monitor{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"nL" = (
+/obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden,
+/obj/machinery/meter,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"nN" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"nO" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 9
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"nR" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/stationmed{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"nS" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/easel,
+/obj/item/canvas/twentythree_nineteen,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"nT" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"ob" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/knife{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 6
+	},
+/obj/structure/cable,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"oc" = (
+/obj/machinery/chem_master,
+/obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"od" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"of" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"og" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"oi" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"ok" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitories"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"on" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"oq" = (
+/obj/effect/turf_decal/tile/brown/half,
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"or" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/item/sign/flag/syndicate{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/glass/waterbottle{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"ot" = (
+/obj/machinery/light/cold/directional/east,
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/stationmed{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"ou" = (
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/computer{
+	name = "syndicate communications console";
+	icon_keyboard = "tech_key";
+	icon_screen = "comm";
+	desc = "A console meant to communicate with Syndicate upper command. This one seems to be busy processing flight calculations since you last saw it..."
+	},
+/obj/item/paper{
+	default_raw_text = "<h1>DS2 Transfer Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>Active syndicate operatives have been transferred over to the target NT workplace and are NOT to be interacted with under any circumstances, unless Syndicate Command allows it. Permission to monitor their activities is granted and heavily suggested.</p><p>Stay winning.</p>";
+	name = "paper- 'DS2 Transfer Report'"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"ov" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"ow" = (
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/closet/secure_closet/medical1{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"oz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"oC" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"oE" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"oG" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 5;
+	faction = list("Syndicate","neutral")
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"oK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"oO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"oR" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/east,
+/obj/structure/rack/shelf,
+/obj/item/crowbar/power/syndicate{
+	pixel_y = 8
+	},
+/obj/item/crowbar/power/syndicate{
+	pixel_y = 2
+	},
+/obj/item/crowbar/power/syndicate{
+	pixel_y = -4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"oS" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"oT" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"oV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/bathroom{
+	id_tag = "TESSkyrim";
+	name = "Restroom"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"oZ" = (
+/obj/machinery/vending/games,
+/obj/machinery/camera/xray/directional/west{
+	network = list("ds2");
+	c_tag = "DS-2 Lounge"
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"pa" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"pb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	id = "ds2disposals"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/garbage{
+	pixel_y = -10
+	},
+/turf/open/floor/iron/pool,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"pe" = (
+/obj/machinery/light/cold/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/filled,
+/obj/effect/turf_decal/siding/white/corner,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"pf" = (
+/obj/structure/sign/poster/contraband/icebox_moment{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"pi" = (
+/obj/machinery/computer/crew/syndie{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"pk" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/module_duplicator,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"pl" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/item/circuitboard/computer/rdconsole,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"pn" = (
+/obj/effect/turf_decal/skyrat_decals/departments/bridge{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"pr" = (
+/obj/machinery/door/poddoor/incinerator_syndicatelava_main{
+	name = "Turbine Exterior Vent"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"ps" = (
+/obj/machinery/computer/cryopod/interdyne{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"pt" = (
+/obj/machinery/light/warm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"pu" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"py" = (
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/tile/dark_red/half,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/machinery/camera/xray/directional/north{
+	network = list("ds2");
+	c_tag = "DS-2 Hangar North"
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"pz" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"pB" = (
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Long-Term Brig"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "DS2permabrig"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"pI" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"pL" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/item/storage/box/firingpins/syndicate{
+	pixel_y = 6;
+	pixel_x = -2
+	},
+/obj/item/storage/box/firingpins/syndicate{
+	pixel_x = 2
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"pO" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"pP" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"pW" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"pX" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	color = "#555555";
+	icon_state = "bathroom-open";
+	id = "DS2cell1";
+	icon_type = "bathroom"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"qa" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/item/storage/box/donkpockets/donkpocketpizza{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"qc" = (
+/obj/structure/bed/double{
+	dir = 1
+	},
+/obj/item/bedsheet/brown/double{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"qh" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"qj" = (
+/obj/structure/dresser,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/royalblack,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"qn" = (
+/obj/machinery/light/no_nightlight/directional/east,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"qo" = (
+/obj/structure/rack/shelf,
+/obj/item/mod/module/chameleon{
+	pixel_x = 6
+	},
+/obj/item/mod/module/chameleon{
+	pixel_y = -6;
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/obj/effect/spawner/random/mod{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/obj/effect/spawner/random/mod,
+/obj/item/mod/construction/broken_core{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/mod/core/standard,
+/obj/item/mod/construction/broken_core{
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"qs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/storage/wallet/random,
+/obj/item/clothing/under/costume/jabroni{
+	has_sensor = 0;
+	random_sensor = 0
+	},
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"qt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"qu" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"qv" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"qw" = (
+/obj/machinery/suit_storage_unit/syndicate/chameleon{
+	name = "suit storage unit";
+	req_access = list("syndicate_leader")
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"qz" = (
+/obj/machinery/power/shuttle_engine/propulsion/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"qC" = (
+/obj/machinery/door/airlock/service/glass{
+	name = "Hydroponics"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"qE" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/magboots/syndie{
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/magboots/syndie,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west{
+	req_access = list("syndicate")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"qH" = (
+/obj/structure/table,
+/obj/machinery/light/cold/directional/east,
+/obj/item/rsf{
+	pixel_y = 14
+	},
+/obj/item/rcd_ammo{
+	pixel_y = 11
+	},
+/obj/item/plate,
+/obj/item/plate{
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_y = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"qI" = (
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/machinery/computer/crew/syndie,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"qK" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"qN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"qO" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "ds2conveyor"
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"qR" = (
+/obj/machinery/vending/imported/mothic,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"qS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"qW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"qY" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access = list("syndicate")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/item/radio{
+	desc = "An old handheld radio. You could use it, if you really wanted to.";
+	icon_state = "radio";
+	name = "old radio";
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"ra" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/airlock/bathroom{
+	name = "Brig Restroom"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"rb" = (
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"rc" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/mob_spawn/ghost_role/human/ds2/prisoner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"rd" = (
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"rg" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"ri" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"rj" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"rk" = (
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/warning,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"rl" = (
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"ro" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/door/airlock/silver/glass{
+	name = "Kitchen"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"rr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"rs" = (
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"rx" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"rz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"rB" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"rD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"rG" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Ship Atmospherics"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"rH" = (
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/bookcase/random{
+	books_to_load = 10
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"rI" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"rM" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/effect/spawner/random/food_or_drink/condiment{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"rN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "External Access"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"rU" = (
+/obj/machinery/dryer{
+	pixel_y = 20;
+	pixel_x = 8
+	},
+/obj/structure/sink/directional/east{
+	pixel_y = -6
+	},
+/obj/structure/mirror/directional/west,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"rY" = (
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"rZ" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"sa" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/bottom/left,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"sc" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"sh" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"sj" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"sl" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/camera/xray/directional/south{
+	network = list("ds2");
+	c_tag = "DS-2 Long-Term Brig Access"
+	},
+/obj/item/card/id/advanced/prisoner/ds2,
+/obj/item/card/id/advanced/prisoner/ds2{
+	pixel_y = 4;
+	trim = /datum/id_trim/syndicom/skyrat/ds2/prisoner
+	},
+/obj/item/card/id/advanced/prisoner/ds2{
+	pixel_y = 8;
+	trim = /datum/id_trim/syndicom/skyrat/ds2/prisoner
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"sr" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"ss" = (
+/obj/effect/turf_decal/vg_decals/numbers/four{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/template_noop)
+"st" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"sy" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/middle/left,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/skyrat_decals/ds2/left,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"sB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"sD" = (
+/obj/machinery/vending/sustenance,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"sH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"sK" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/circuit/off,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"sL" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"sM" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 8
+	},
+/obj/structure/showcase/cyborg{
+	icon = 'icons/mob/silicon/robots.dmi';
+	icon_state = "synd_sec";
+	name = "syndicate cyborg showcase";
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 4;
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"sO" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/food_or_drink/donkpockets_single{
+	pixel_x = -4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"sP" = (
+/obj/effect/turf_decal/trimline/purple/filled/end,
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"sV" = (
+/obj/item/storage/box/beakers/bluespace{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/item/storage/box/beakers/bluespace{
+	pixel_x = 2
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/bag/chemistry{
+	pixel_x = -16
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"sW" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"sZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/dinnerware{
+	onstation = 0
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"tf" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"tg" = (
+/obj/machinery/shower/directional/south,
+/obj/item/soap/syndie,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"tk" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"tl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	id = "ds2disposals"
+	},
+/turf/open/floor/iron/pool,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"tm" = (
+/obj/machinery/vending/assist,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"tn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"tq" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"tt" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/brown/double,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"tA" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/obj/item/paper{
+	default_raw_text = "<h1>Gorlex Engineering</h1><p>New to setting up a turbine, operative? This neat little guide and set-up should teach you how, step by step.</p><p>The first step is setting up the burn chamber. The Air alarm is unlocked for syndicate access, and a single scrubber in the area is inactive. That is our burn chamber's scrubber. Set it to scoop up any gas you don't want in it - anything but plasma and oxygen - and set it on expanded reach.</p><p>Next is setting up the Plasma Mixer. A good ratio is somewhere between 30-70 and 40-60 Plasma and Oxygen, respectively. Don't forget to max out the mixer's pressure, else it'll only dribble in the gas!</p><p>Once that is done, make sure to activate the two digital valves on the floor. One will allow O2 to be brought to the mixer, and the other one will lead the gas mix directly into the chamber.</p><p>With the burn being ready, two last things are needed. First, you'll need to set up the ship's scrubbers system to actively pump into space the excess gasses (Water vapour, Co2) the burn will produce. If you want, you can select a gas to filter out, but that isn't necessary. Once everything is set up, flick the igniter switch on, turn on the turbine at the terminal, and watch that fire shine bright!</p>";
+	name = "paper- 'Gorlex Engineering Division - Turbine Easy-Set Guide'"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"tC" = (
+/obj/machinery/door/airlock/research{
+	name = "Robotics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"tD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/camera/xray/directional/west{
+	network = list("ds2");
+	c_tag = "DS-2 Security Checkpoint"
+	},
+/obj/machinery/computer/crew/syndie{
+	dir = 1
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"tE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"tG" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"tL" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/item/storage/medkit/advanced{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/item/storage/medkit/regular{
+	pixel_y = 1;
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"tN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"tP" = (
+/obj/machinery/door/airlock/security/old{
+	hackProof = 1;
+	name = "Armory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"tQ" = (
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"tR" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"tS" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/seeds/tower,
+/obj/structure/window/reinforced/survival_pod,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/light/cold/directional/west,
+/obj/item/seeds/tobacco,
+/obj/item/reagent_containers/cup/watering_can,
+/obj/item/cultivator,
+/obj/item/plant_analyzer,
+/obj/item/secateurs,
+/obj/item/shovel/spade,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"tT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"tU" = (
+/obj/machinery/door/airlock/medical{
+	name = "Chemistry"
+	},
+/obj/effect/turf_decal/stripes/blue/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/blue/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"tY" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "ds2detective";
+	name = "Interrogation Room Shutters"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"tZ" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"ub" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"uc" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ue" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/closet/crate/goldcrate,
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"uf" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"uh" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"ui" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESBattlespire";
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"um" = (
+/obj/structure/reagent_dispensers/plumbed,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"uo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"uq" = (
+/obj/machinery/power/shuttle_engine/large,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"uu" = (
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"uA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"uB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/donk,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"uD" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"uE" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/safe,
+/obj/item/storage/box/syndie_kit/chameleon/ghostcafe{
+	desc = "A sleek, sturdy box.";
+	name = "Chameleon Kit"
+	},
+/obj/item/reagent_containers/heroinbrick{
+	name = "Tiger Coop stimulant brick";
+	desc = "A brick of stimulants meant for use by Tiger Cooperative agents. It seems this one's just a brittle block of heroin."
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"uL" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"uN" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"uS" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Cell 1"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"uV" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"uW" = (
+/obj/structure/tank_holder/anesthetic,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"va" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ds2bridge"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"vc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"vd" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/cyborgrecharger,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"ve" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"vg" = (
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"vl" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"vo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/rack/shelf,
+/obj/item/stock_parts/cell/lead{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/stock_parts/cell/lead,
+/obj/item/stock_parts/cell/lead{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"vp" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"vq" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"vr" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/masteratarms,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"vv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access = list("syndicate")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"vx" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "cap";
+	name = "\proper station admiral's locker";
+	req_access = list("syndicate")
+	},
+/obj/item/clothing/head/hats/hos/syndicate,
+/obj/item/clothing/head/hos/beret/syndicate,
+/obj/item/clothing/suit/armor/vest/capcarapace/syndicate,
+/obj/item/clothing/under/rank/captain/skyrat/utility/syndicate,
+/obj/item/radio/headset/interdyne/command,
+/obj/item/clothing/suit/armor/vest/capcarapace/syndicate/winter,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/ammo_box/magazine/m9mm_aps,
+/obj/item/clothing/accessory/medal/gold{
+	name = "medal of admiralty";
+	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of an Admiral to the Sothran Syndicate, and their undisputable authority over their crew."
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"vA" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "ds2";
+	map_pad_link_id = "interdyne";
+	name = "quantum pad to Interdyne"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"vB" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"vD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"vE" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/airalarm/syndicate{
+	pixel_y = -24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"vF" = (
+/obj/structure/curtain,
+/obj/structure/drain,
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"vK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/paper{
+	default_raw_text = "<h1>DS2 Long-Term Brig Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>The Sothran Syndicate has been capable of kidnapping a few key NT workers of various hierarchy levels. It is your task to interrogate, question and break their wills in order to find more intel on our enemy, Nanotrasen.</p><p>Stay winning.";
+	name = "paper- 'DS2 Long-Term Brig Report'"
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"vM" = (
+/obj/effect/turf_decal/trimline/yellow/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"vO" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"vQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"vR" = (
+/obj/machinery/disposal/delivery_chute{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	id = "ds2disposals"
+	},
+/turf/open/floor/iron/pool,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"vS" = (
+/obj/machinery/porta_turret/syndicate/energy,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"vT" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/vending/toyliberationstation,
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"vU" = (
+/turf/open/floor/engine/plasma,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"wc" = (
+/obj/structure/bed/maint,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"we" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"wg" = (
+/turf/template_noop,
+/area/template_noop)
+"wh" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/hedge,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"wj" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"wk" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/syndicate,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"wm" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"wn" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"wp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"wt" = (
+/obj/effect/turf_decal/box/red/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"wu" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/bottom/middle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"wz" = (
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/computer/security{
+	network = list("ds2");
+	dir = 4
+	},
+/obj/structure/sign/flag/syndicate/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"wE" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"wH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"wJ" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/top/middle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"wN" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"wS" = (
+/obj/machinery/igniter/incinerator_syndicatelava,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"wV" = (
+/obj/machinery/processor,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"xb" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"xc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"xd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/white,
+/obj/item/toy/figure/syndie{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/machinery/camera/xray/directional/south{
+	network = list("ds2");
+	c_tag = "DS-2 Hangar South"
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"xk" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"xp" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"xr" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"xu" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"xx" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"xy" = (
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"xB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"xG" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"xH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"xQ" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"xS" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"xX" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"xZ" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ya" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/cmo/glass{
+	name = "Medical Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"yd" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	name = "Master At Arms Shutters";
+	id = "smasteratarms"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"ye" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/vending/drugs{
+	name = "\improper SyndiDrug Plus";
+	onstation = 0
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"yh" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/structure/table,
+/obj/item/coin/iron{
+	pixel_x = -10
+	},
+/obj/item/toy/cards/deck,
+/obj/item/storage/dice{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"yi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"yn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"yu" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"yv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"yy" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"yH" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"yI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"yL" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/closet/secure_closet{
+	name = "prisoner item locker";
+	req_access = list("syndicate_leader")
+	},
+/obj/item/restraints/handcuffs,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"yP" = (
+/obj/structure/chair,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/camera/directional/west{
+	network = list("ds2");
+	c_tag = "DS-2 Dormitories"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"yR" = (
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"yS" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
+	},
+/obj/structure/showcase/cyborg{
+	icon = 'icons/mob/silicon/robots.dmi';
+	icon_state = "synd_sec";
+	name = "syndicate cyborg showcase";
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 8;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"yU" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"yX" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"zb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"zc" = (
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/tile/dark_red/half,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/machinery/light/red/directional/north,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"zd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"ze" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "External Access"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"zg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/circuitboard/machine/protolathe,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"zh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Janitorial Supplies"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"zl" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"zn" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"zp" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"zq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"zt" = (
+/obj/structure/table/glass,
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"zv" = (
+/obj/effect/turf_decal/vg_decals/numbers/zero{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine/hull,
+/area/template_noop)
+"zx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/green/visible,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"zy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/light/warm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"zA" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"zD" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_y = 3;
+	pixel_x = -5
+	},
+/obj/item/pen{
+	pixel_y = 3;
+	pixel_x = -5
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"zH" = (
+/turf/open/floor/carpet/donk,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"zI" = (
+/obj/machinery/power/shuttle_engine/large{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"zK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"zL" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"zM" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"zN" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"zS" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"zU" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"zV" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"zX" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/shuttle_engine/heater,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"Aa" = (
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/table,
+/obj/machinery/ecto_sniffer,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Ae" = (
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/security/old{
+	hackProof = 1;
+	name = "Long-Term Brig"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "DS2permabrig"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Af" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Al" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"An" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "External Access"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Ao" = (
+/obj/structure/sink/directional/east{
+	pixel_x = -11
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Ar" = (
+/obj/machinery/smartfridge/food,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"At" = (
+/obj/structure/dresser,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"Au" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Av" = (
+/obj/machinery/computer/atmos_alert,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Aw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Ax" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Ay" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Az" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/clothing/under/syndicate/skyrat/baseball,
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"AC" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"AG" = (
+/obj/item/ammo_box/c9mm{
+	pixel_x = -2
+	},
+/obj/item/ammo_box/c9mm{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/ammo_box/advanced/s12gauge{
+	pixel_x = 9;
+	pixel_y = -10
+	},
+/obj/item/ammo_box/advanced/s12gauge{
+	pixel_x = 9;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/advanced/s12gauge/rubber{
+	pixel_y = -10;
+	pixel_x = -9
+	},
+/obj/item/ammo_box/advanced/s12gauge/rubber{
+	pixel_y = -5;
+	pixel_x = -9
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "riot";
+	name = "armory munitions locker";
+	req_access = list("syndicate_leader");
+	icon = 'modular_skyrat/master_files/icons/obj/closet.dmi';
+	anchored = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"AI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_blue/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"AK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"AR" = (
+/obj/machinery/light/red/directional/south,
+/obj/machinery/airalarm/syndicate{
+	pixel_y = -24
+	},
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"AV" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"AW" = (
+/obj/machinery/light/warm/directional/south,
+/obj/machinery/button/door/directional/south{
+	desc = "Keep out the Truth.";
+	id = "ds2detective";
+	name = "Interrogation Room shutters control";
+	req_access = list("syndicate")
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"AX" = (
+/obj/item/reagent_containers/cup/glass/waterbottle{
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/trimline/dark/line,
+/obj/effect/turf_decal/trimline/dark/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"AZ" = (
+/obj/machinery/vending/boozeomat/syndicate_access,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Bb" = (
+/obj/effect/turf_decal/vg_decals/atmos/oxygen{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Be" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Bi" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/red/directional/north,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"Bj" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/obj/structure/sign/poster/contraband/kss13{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Bk" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Bm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	id = "ds2disposals"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/cigbutt{
+	pixel_y = -10
+	},
+/turf/open/floor/iron/pool,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Bs" = (
+/obj/structure/lattice,
+/obj/structure/transit_tube{
+	dir = 8
+	},
+/obj/machinery/camera/xray/directional/north{
+	network = list("ds2");
+	c_tag = "DS-2 Transit Tube"
+	},
+/turf/template_noop,
+/area/template_noop)
+"Bt" = (
+/obj/structure/sink/kitchen/directional/west,
+/obj/structure/sign/poster/contraband/moffuchis_pizza{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Bu" = (
+/obj/machinery/suit_storage_unit/syndicate/chameleon{
+	name = "suit storage unit";
+	req_access = list("syndicate_leader")
+	},
+/obj/machinery/power/apc/auto_name/directional/east{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Bv" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/rack/shelf,
+/obj/item/shovel{
+	pixel_y = 2
+	},
+/obj/item/pickaxe{
+	pixel_y = -4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Bw" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "ds2fakelevator";
+	pixel_y = 12;
+	desc = "An elevator control switch. This one seems defunct.";
+	name = "elevator control"
+	},
+/obj/structure/railing/corner{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"By" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/airlock/cmo/glass{
+	name = "Medical Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"BC" = (
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/chem_master/condimaster{
+	name = "BrewMaster 3000"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"BG" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/miner,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"BL" = (
+/obj/structure/table,
+/obj/item/book/manual/chef_recipes,
+/obj/item/reagent_containers/condiment/enzyme,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 2
+	},
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"BN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"BO" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"BS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"BV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"Cb" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Cd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Ce" = (
+/obj/structure/drain,
+/obj/machinery/shower/directional/east,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Cf" = (
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Ch" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/window/survival_pod{
+	req_access = list("syndicate");
+	name = "Diner"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Cj" = (
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"Cm" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/corporateliaison,
+/turf/open/floor/carpet/donk,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"Cn" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/incinerator_syndicatelava_aux{
+	name = "Combustion Chamber Blast Door"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Cp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Cq" = (
+/obj/effect/turf_decal/skyrat_decals/departments/bridge{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Ct" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Cy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"CC" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"CE" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"CF" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/miner,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"CH" = (
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"CJ" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/power/shuttle_engine/heater,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"CS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/item/toy/figure/syndie{
+	pixel_y = 20;
+	pixel_x = 10
+	},
+/obj/item/toy/figure/syndie{
+	pixel_y = 23
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"CT" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"CV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"CX" = (
+/obj/machinery/light/warm/directional/north,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 5
+	},
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/enginetech{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"De" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Dh" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Dk" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/recharger,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Dm" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Dr" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Ds" = (
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Dt" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Du" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Dv" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Dw" = (
+/obj/structure/closet/emcloset,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/light/red/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Dy" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"Dz" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"DA" = (
+/obj/effect/turf_decal/bot,
+/obj/item/disk{
+	desc = "A cheap, plastic hard-disk labelled 'good tunes to assault ops to'. It looks disused... wait, is that a 'THE WEAPONIZED' logo?";
+	icon_state = "nucleardisk";
+	name = "dat fukken disk"
+	},
+/obj/item/choice_beacon/music{
+	pixel_x = 5
+	},
+/obj/item/choice_beacon/music{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/crate/wooden,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"DB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"DE" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "TESArena";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	specialfunctions = 4;
+	pixel_y = 24
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"DF" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/fax{
+	fax_name = "Unknown Syndicate Fax";
+	name = "DS-2 Fax Machine";
+	pixel_y = 7;
+	syndicate_network = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"DH" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/structure/table/glass,
+/obj/item/gun/energy/floragun{
+	pixel_y = 7
+	},
+/obj/item/geneshears,
+/obj/item/plant_analyzer{
+	pixel_x = -7
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"DI" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	name = "E.V.A."
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"DJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"DK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"DL" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"DS" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Eb" = (
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Ec" = (
+/obj/structure/transit_tube/station/dispenser/reverse,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Ed" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Ej" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "ds2cargo";
+	pixel_x = 24;
+	req_access = list("syndicate");
+	name = "Cargo Blastdoor Control"
+	},
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Em" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/structure/sign/flag/syndicate/directional/south{
+	pixel_x = -16
+	},
+/obj/structure/rack/shelf,
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_y = 3;
+	pixel_x = -2
+	},
+/obj/item/clothing/mask/gas/alt{
+	pixel_x = -2
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/gas/alt{
+	pixel_y = -3;
+	pixel_x = 6
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"En" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Ew" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Ey" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Ez" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"EB" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/engivend{
+	onstation = 0
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"EC" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/obj/item/grenade/barrier{
+	pixel_y = 10
+	},
+/obj/item/grenade/barrier{
+	pixel_y = 6;
+	pixel_x = 4
+	},
+/obj/item/grenade/barrier{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/grenade/barrier{
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"EJ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/template_noop,
+/area/template_noop)
+"EL" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"EP" = (
+/obj/machinery/light/warm/directional/north,
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"EQ" = (
+/obj/machinery/duct,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"ET" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	id = "ds2disposals"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/effect/spawner/random/trash/botanical_waste,
+/obj/effect/spawner/random/trash/food_packaging{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/trash/can/food/peaches{
+	pixel_y = -6;
+	pixel_x = 6
+	},
+/turf/open/floor/iron/pool,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"EU" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"EV" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/machinery/light/warm/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"EW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"EY" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"EZ" = (
+/obj/effect/spawner/random/contraband/prison,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/random/trash/food_packaging{
+	pixel_y = -5
+	},
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Fa" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Fb" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Fc" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Fe" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Fh" = (
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Fi" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Fj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Fk" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	name = "Master At Arms Shutters";
+	id = "smasteratarms";
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Fl" = (
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Fm" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Research"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Fo" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Fw" = (
+/obj/machinery/shower/directional/south,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"Fx" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/door/window/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"Fy" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters{
+	name = "Armory Shutters";
+	id = "ds2armory"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Fz" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"FA" = (
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"FB" = (
+/obj/structure/chair/office/light,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"FC" = (
+/obj/structure/cable,
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"FD" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/button/door/directional/north{
+	desc = "Keep out the paperwork.";
+	id = "scorpliaison";
+	name = "Corporate Liaison's room bolt";
+	normaldoorcontrol = 1;
+	req_access = list("syndicate_leader");
+	specialfunctions = 4
+	},
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"FG" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"FH" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"FJ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/syringes,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"FO" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "med_secure";
+	name = "medical gear locker";
+	req_access = list("syndicate")
+	},
+/obj/item/clothing/gloves/color/latex/nitrile/ntrauma,
+/obj/item/clothing/suit/toggle/labcoat/interdyne,
+/obj/item/clothing/suit/toggle/labcoat/interdyne,
+/obj/item/storage/belt/medbandolier{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/belt/medbandolier{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/hud/ar/aviator/health,
+/obj/item/clothing/glasses/hud/ar/aviator/health,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"FP" = (
+/obj/machinery/computer/crew/syndie{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"FY" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"FZ" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Gb" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Gd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/light/red/directional/south,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/item/toy/figure/syndie{
+	pixel_y = -1;
+	pixel_x = -12
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Ge" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Gg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Gh" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/curtain{
+	id = "DS2cell1";
+	name = "curtain control";
+	pixel_y = -24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Gi" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Gk" = (
+/obj/machinery/power/turbine/core_rotor{
+	mapping_id = "syndicatelava_turbine"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Gl" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table,
+/obj/item/choice_beacon/ingredient{
+	pixel_y = 11
+	},
+/obj/item/choice_beacon/ingredient{
+	pixel_y = 2;
+	pixel_x = -5
+	},
+/obj/structure/cable,
+/obj/item/clothing/accessory/armband/hydro{
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "service armband";
+	pixel_x = 15
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_y = 8;
+	pixel_x = 17
+	},
+/obj/item/storage/belt/military/snack,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Gt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Gx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Gz" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"GD" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"GE" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/engineering/flashlight,
+/obj/effect/spawner/random/clothing/twentyfive_percent_cyborg_mask,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"GG" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"GH" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"GK" = (
+/obj/machinery/power/shuttle_engine/huge,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"GL" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/toy/crayon/spraycan{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"GO" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"GR" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"GS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"GU" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"GV" = (
+/obj/structure/table/wood,
+/obj/item/camera{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/paper{
+	default_raw_text = "<h1>DS2 Command Report</h1><p>The Deep Space 2 Forward Operating Base has successfully relocated itself near active Nanotrasen installations. Reboot of shuttle engines in progress...</p><p>The Sothran Syndicate is glad to have you on-field, admiral. Nanotrasen is in the direct sector and, as such, is the direct target of our operatives. Manage your crew well and with respect, and leave all your anger to the gravel that is Nanotrasen. Remember that Interdyne has an unaffiliated facade to keep up, as such, advise against your crew flaunting their affiliation to non-crew.</p><p>Stay winning.</p>";
+	name = "paper- 'DS2 Command Report'"
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"GX" = (
+/obj/structure/sign/flag/syndicate/directional/south{
+	pixel_x = 16
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/white,
+/obj/item/toy/figure/syndie{
+	pixel_x = -10
+	},
+/obj/item/toy/figure/syndie{
+	pixel_y = -3;
+	pixel_x = 4
+	},
+/obj/structure/shipping_container/donk_co{
+	pixel_x = -17;
+	pixel_y = 15;
+	desc = "A standard-measure shipping container for bulk transport of goods. This one is from Donk Co. and so could be carrying just about anything- although it seems this one is overflowing with little Syndicate Figurines, known for being sold at a Loss."
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"GY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Ha" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/survival_pod{
+	req_access = list("syndicate_leader");
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Hb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp{
+	color = "#DE3A3A"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Hc" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/structure/rack/gunrack,
+/obj/item/gun/ballistic/shotgun/riot/syndicate,
+/obj/item/gun/ballistic/shotgun/riot/syndicate{
+	pixel_x = -10
+	},
+/obj/item/gun/ballistic/shotgun/riot/syndicate{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Hh" = (
+/obj/structure/table,
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Hn" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Hq" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Hr" = (
+/obj/machinery/oven,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Ht" = (
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/machinery/computer/shuttle{
+	desc = "A shuttle terminal which allows a connection to the DS-2 forward base's supply shuttle.";
+	icon_keyboard = "syndie_key";
+	icon_screen = "syndishuttle";
+	light_color = "#FA8282";
+	name = "syndicate cargo shuttle terminal";
+	possible_destinations = "IP-DS-2";
+	req_access = list("syndicate");
+	shuttleId = "syndie_cargo"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Hu" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/cup/bowl,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/reagent_containers/cup/bowl,
+/obj/item/reagent_containers/cup/bowl,
+/obj/item/reagent_containers/cup/bowl,
+/obj/item/reagent_containers/cup/bowl,
+/obj/item/reagent_containers/cup/bowl,
+/obj/item/reagent_containers/cup/bowl,
+/obj/item/reagent_containers/cup/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/kitchen/rollingpin,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Hw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Hz" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"HA" = (
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4
+	},
+/obj/item/clothing/glasses/science{
+	pixel_x = -4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"HD" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"HE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"HF" = (
+/obj/machinery/suit_storage_unit/syndicate/chameleon{
+	name = "suit storage unit"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"HH" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"HI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"HK" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "ds2conveyor"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"HV" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "ds2conveyor"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"HZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Ia" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"Ih" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Ii" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"Im" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/light/warm/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Io" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Ir" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Iw" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"IA" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/corner{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"IC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/floor{
+	use_power = 0
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"IH" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/item/circuitboard/machine/destructive_analyzer,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"IM" = (
+/obj/structure/closet/crate/medical,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/medical/medkit{
+	pixel_y = 3;
+	pixel_x = 6
+	},
+/obj/effect/spawner/random/medical/supplies{
+	pixel_y = 3
+	},
+/obj/effect/spawner/random/medical/medkit{
+	pixel_y = -3;
+	pixel_x = -6
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"IN" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/item/sign/flag/syndicate{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/cup/maunamug{
+	pixel_x = 4
+	},
+/turf/open/floor/carpet/donk,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"IQ" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"IU" = (
+/obj/item/circuitboard/machine/ammo_workbench,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/obj/item/disk/ammo_workbench/lethal,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"IV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"IZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/obj/machinery/suit_storage_unit{
+	mask_type = /obj/item/clothing/mask/gas/syndicate;
+	storage_type = /obj/item/tank/jetpack/oxygen/harness;
+	mod_type = /obj/item/mod/control/pre_equipped/traitor_elite
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"Jd" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"Jf" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null
+	},
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/effect/spawner/random/contraband/permabrig_weapon,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/item/storage/box/ingredients/random,
+/obj/item/storage/box/ingredients/random,
+/obj/effect/turf_decal/bot_white,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Jl" = (
+/obj/machinery/light/cold/directional/west,
+/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/trash/empty_food_tray{
+	pixel_y = 7
+	},
+/obj/item/newspaper{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/trash/can{
+	pixel_x = -9
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Jv" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Jy" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Jz" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"JA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"JB" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"JC" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"JD" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "warden";
+	name = "master at arms' locker";
+	req_access = list("syndicate_leader")
+	},
+/obj/item/storage/belt/security/full,
+/obj/item/radio/headset/interdyne,
+/obj/item/clothing/suit/armor/vest/warden/syndicate,
+/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,
+/obj/item/clothing/head/beret/sec/navywarden/syndicate,
+/obj/item/clothing/under/suit/skyrat/helltaker{
+	has_sensor = 0;
+	random_sensor = 0
+	},
+/obj/item/clothing/suit/armor/hos/trenchcoat{
+	armor = list("melee"=35,"bullet"=30,"laser"=30,"energy"=40,"bomb"=25,"bio"=0,"fire"=50,"acid"=50,"wound"=10);
+	desc = "A trenchcoat enhanced with a special lightweight kevlar. It has little Syndicate logos sewn onto the shoulder badges with the letters 'MAA' just under it.";
+	name = "Master at arms' armored trenchcoat"
+	},
+/obj/item/clothing/suit/armor/hos{
+	armor = list("melee"=35,"bullet"=30,"laser"=30,"energy"=40,"bomb"=25,"bio"=0,"fire"=50,"acid"=50,"wound"=10);
+	desc = "A greatcoat enhanced with a special alloy for some extra protection and style for those with a likely chance to get bullied for being outside of the brig";
+	name = "Master at arms' armored greatcoat"
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/clothing/head/hos/beret/syndicate,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/clothing/mask/gas/sechailer/syndicate,
+/obj/item/watertank/pepperspray,
+/obj/item/clothing/accessory/medal/silver{
+	name = "military excellence medal";
+	desc = "The Sothran Syndicate's dictionary defines excellence as \"the ability to crush NT scum under one's boot\". This is awarded to those rare operatives who fit that definition."
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"JE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"JF" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"JI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/vending/cigarette/syndicate,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"JK" = (
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/item/ai_module/reset/purge{
+	pixel_y = -7;
+	pixel_x = -2
+	},
+/obj/item/ai_module/reset/purge{
+	pixel_y = -4
+	},
+/obj/item/ai_module/supplied/freeform{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/ai_module/supplied/freeform{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"JL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"JN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"JR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"JS" = (
+/obj/machinery/button/door/directional/east{
+	desc = "To keep the void away.";
+	id = "ds2bridge";
+	name = "Bridge Blast Door Control";
+	req_access = list("syndicate_leader");
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"JZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/light/small/red/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/xray/directional/east{
+	c_tag = "DS-2 Engineering Airlock";
+	network = list("ds2")
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Kb" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 1;
+	req_access = list("syndicate_leader")
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Kd" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/bottom/right,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Ke" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Kf" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"Kg" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Kh" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/mod/maint,
+/obj/effect/spawner/random/mod/maint{
+	pixel_y = -3
+	},
+/obj/effect/spawner/random/mod/maint{
+	pixel_y = -6
+	},
+/obj/structure/closet/crate/science,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Kj" = (
+/obj/effect/turf_decal/trimline/dark_green/warning{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Kk" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Ku" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Kz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/stripes/end,
+/obj/effect/turf_decal/siding/dark/end,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"KC" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"KG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"KI" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/white/corners,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"KJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/cold/directional/north,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/rods/fifty{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"KM" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"KN" = (
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/delivery/red,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "DS2brig"
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"KQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"KS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"KT" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"KV" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"KY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"Lb" = (
+/obj/effect/turf_decal/tile/dark_red/half,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Le" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"Lf" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"Lg" = (
+/obj/machinery/atmospherics/miner/plasma,
+/turf/open/floor/engine/plasma,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Ll" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Lo" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Lq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Lr" = (
+/obj/machinery/oven,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Ls" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "eng";
+	name = "welding supplies locker";
+	req_access = list("syndicate");
+	icon_door = "eng_weld"
+	},
+/obj/item/weldingtool/largetank{
+	pixel_y = 4
+	},
+/obj/item/weldingtool/largetank{
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Lv" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/storage/belt/holster/nukie{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/storage/belt/holster/nukie{
+	pixel_y = 6
+	},
+/obj/item/storage/belt/holster/nukie{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -8
+	},
+/obj/item/storage/belt/military{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/clothing/head/helmet{
+	pixel_y = -7
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = 6;
+	pixel_y = -11
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "riot";
+	name = "armory gear locker";
+	req_access = list("syndicate_leader");
+	icon = 'modular_skyrat/master_files/icons/obj/closet.dmi';
+	anchored = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Lw" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Lx" = (
+/obj/machinery/door/airlock/security/old{
+	hackProof = 1;
+	name = "Master At Arms' Office";
+	id_tag = "smasteratarms"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Lz" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"LA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"LB" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/researcher,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"LG" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"LK" = (
+/obj/structure/sign/flag/syndicate/directional/south,
+/obj/machinery/light/warm/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"LM" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "ds2conveyor"
+	},
+/obj/structure/railing,
+/obj/machinery/door/poddoor{
+	id = "ds2cargo"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"LP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"LQ" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/item/poster/random_contraband{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"LT" = (
+/obj/structure/toilet{
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"LV" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/enginetech{
+	dir = 8
+	},
+/obj/machinery/light/warm/directional/north,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"LY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/camera/xray/directional/south{
+	network = list("ds2");
+	c_tag = "DS-2 Armory"
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/item/storage/box/pinpointer_pairs{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/storage/box/pinpointer_pairs,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Mg" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Mk" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Mn" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Mo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Mt" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"Mw" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/item/plate,
+/obj/item/food/poutine{
+	pixel_y = 2
+	},
+/obj/item/food/poutine{
+	pixel_y = 5
+	},
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"MB" = (
+/obj/item/clothing/suit/toggle/labcoat/skyrat/hospitalgown{
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/item/clothing/suit/toggle/labcoat/skyrat/hospitalgown{
+	pixel_x = -7
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/glass/waterbottle{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/machinery/light/cold/directional/north,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"MC" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_y = 3
+	},
+/obj/item/pen/fountain/captain{
+	name = "admiral's fountain pen";
+	pixel_y = 5
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"ME" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	name = "Admiral Shutters";
+	id = "ds2admiral";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"MF" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"MG" = (
+/obj/structure/drain,
+/obj/machinery/shower/directional/east{
+	pixel_x = -13
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"MH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/camera/xray/directional/east{
+	network = list("ds2");
+	c_tag = "DS-2 EVA"
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"MK" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"MM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"MP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"MT" = (
+/obj/machinery/computer/shuttle{
+	desc = "A shuttle terminal which allows a connection to the DS-2 forward base's supply shuttle.";
+	icon_keyboard = "syndie_key";
+	icon_screen = "syndishuttle";
+	light_color = "#FA8282";
+	name = "syndicate cargo shuttle terminal";
+	possible_destinations = "IP-DS-2";
+	req_access = list("syndicate");
+	shuttleId = "syndie_cargo"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"MZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
+	},
+/obj/structure/sign/flag/syndicate/directional/north,
+/obj/structure/showcase/cyborg{
+	icon = 'icons/mob/silicon/robots.dmi';
+	icon_state = "synd_sec";
+	name = "syndicate cyborg showcase";
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 4;
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Nb" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Nc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"Ne" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/button/door/directional/south{
+	id = "dorms-view";
+	req_access = list("syndicate");
+	name = "Dorms Blast Door Control"
+	},
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"Ng" = (
+/obj/effect/turf_decal/vg_decals/atmos/plasma{
+	dir = 4
+	},
+/turf/open/floor/engine/plasma,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Ni" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/item/paint_palette,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Nk" = (
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	hackProof = 1
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Nl" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/researcher,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Nm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"No" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/silver/glass{
+	name = "Kitchen"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"Nr" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Ns" = (
+/obj/structure/sign/flag/syndicate/directional/north{
+	pixel_x = 16
+	},
+/obj/effect/turf_decal/tile/dark_red/half,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"NA" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/button/door/incinerator_vent_syndicatelava_aux{
+	pixel_y = 24;
+	pixel_x = -6;
+	name = "Combustion Chamber Blast Door Control"
+	},
+/obj/machinery/button/door/incinerator_vent_syndicatelava_main{
+	pixel_x = -6;
+	pixel_y = -24;
+	name = "Turbine Exterior Vent Control"
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"NB" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"NC" = (
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"NG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/syndicate{
+	pixel_y = -24
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"NL" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/arrows,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"NN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"NO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Fitness"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"NP" = (
+/obj/item/storage/belt/security/full,
+/obj/item/radio/headset/interdyne,
+/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,
+/obj/item/storage/belt/security/webbing/ds,
+/obj/item/clothing/head/beret/sec/syndicate,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/item/clothing/accessory/armband{
+	name = "brig officer armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "brig officer gear locker";
+	req_access = list("syndicate_leader")
+	},
+/obj/item/clothing/mask/gas/syndicate/ds,
+/obj/item/clothing/suit/toggle/jacket/sec/old{
+	name = "brig officer jacket"
+	},
+/obj/item/clothing/mask/gas/sechailer/syndicate,
+/obj/item/gun/energy/disabler,
+/obj/item/clothing/glasses/hud/security/sunglasses/eyepatch/redsec,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"NQ" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"NR" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "ds2conveyor"
+	},
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"NS" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/hug{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"NT" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"NW" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"NX" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479"
+	},
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"NY" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Ob" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_corner,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Oc" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Od" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 8;
+	pixel_y = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/firealarm/directional/east,
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_y = -7;
+	pixel_x = -6
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Oe" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/box/white,
+/obj/item/reagent_containers/cup/glass/waterbottle{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Oi" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"Ok" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Op" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light/warm/directional/east,
+/obj/machinery/vending/snack,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Ov" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 17
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_y = 10;
+	pixel_x = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/crowbar/red,
+/obj/item/assembly/flash/handheld{
+	pixel_y = 7;
+	pixel_x = -6
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Ox" = (
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Oy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"OC" = (
+/obj/item/storage/belt/security/full,
+/obj/item/radio/headset/interdyne,
+/obj/item/clothing/under/rank/security/skyrat/utility/redsec/syndicate,
+/obj/item/storage/belt/security/webbing/ds,
+/obj/item/clothing/head/beret/sec/syndicate,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/item/clothing/accessory/armband{
+	name = "brig officer armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "brig officer gear locker";
+	req_access = list("syndicate_leader")
+	},
+/obj/item/clothing/mask/gas/syndicate/ds,
+/obj/item/clothing/suit/toggle/jacket/sec/old{
+	name = "brig officer jacket"
+	},
+/obj/item/clothing/mask/gas/sechailer/syndicate,
+/obj/item/gun/energy/disabler,
+/obj/item/clothing/glasses/hud/security/sunglasses/eyepatch/redsec,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"OD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"OF" = (
+/obj/effect/turf_decal/trimline/dark_green/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"OK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"ON" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"OP" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/top/left,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"OT" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/obj/machinery/computer/cryopod/interdyne{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"OU" = (
+/obj/effect/turf_decal/trimline/dark_green/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Pe" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"Pf" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"Pi" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/conveyor_switch/oneway{
+	id = "ds2disposals";
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Pn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Po" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Pq" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/xray/directional/west{
+	network = list("ds2");
+	c_tag = "DS-2 Engineering"
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Pt" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Px" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/window/reinforced/survival_pod,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Py" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Cell 2"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"PA" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/structure/closet/secure_closet{
+	icon_state = "science";
+	name = "scientist gear locker";
+	req_access = list("syndicate")
+	},
+/obj/item/clothing/under/rank/rnd/scientist/skyrat/utility/syndicate,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/clothing/suit/toggle/labcoat/science,
+/obj/item/clothing/under/rank/rnd/scientist/skyrat/utility/syndicate{
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/sunglasses/chemical,
+/obj/item/clothing/accessory/armband/science{
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "researcher armband"
+	},
+/obj/item/clothing/accessory/armband/science{
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "researcher armband"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"PM" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"PO" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"PP" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"PR" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"PS" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"PU" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/grill,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"PV" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"PW" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"PX" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"PY" = (
+/obj/structure/punching_bag,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"Qa" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Qb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Qe" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Qh" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Qi" = (
+/obj/structure/mirror/directional/north,
+/obj/structure/sink/directional/south,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Qo" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/sink/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"Qp" = (
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Qs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/bed/dogbed,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/mob/living/simple_animal/pet/fox{
+	name = "Rhials"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"Qw" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west{
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/arrows{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/machinery/computer/order_console/mining/interdyne,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Qx" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Qz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"QA" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/effect/spawner/random/maintenance/five,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/structure/closet/crate,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"QB" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/east{
+	desc = "To keep your food away from the carp.";
+	id = "diner-view";
+	name = "Diner Blast Door Control";
+	req_access = list("syndicate");
+	pixel_y = -24
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"QC" = (
+/obj/effect/turf_decal/trimline/dark_green/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/east,
+/obj/structure/disposalpipe/junction{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"QE" = (
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"QF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"QG" = (
+/obj/effect/turf_decal/box/red/corners{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"QH" = (
+/obj/item/folder/syndicate,
+/obj/item/laser_pointer/upgraded{
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"QK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"QM" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"QN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"QO" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"QQ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"QV" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"QW" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"QY" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Ra" = (
+/obj/effect/turf_decal/box/red/corners,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Rb" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"Rc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Rd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 7
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Re" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"Rf" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Rh" = (
+/obj/machinery/vending/cola/red,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Rj" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/obj/item/mod/module/rad_protection,
+/obj/item/analyzer,
+/obj/item/mod/module/visor/meson{
+	pixel_y = -9
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Rm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Rp" = (
+/obj/structure/sign/flag/syndicate/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Rr" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Rt" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Ru" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Rx" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Rz" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west{
+	req_access = list("syndicate")
+	},
+/obj/effect/spawner/random/food_or_drink/pizzaparty{
+	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
+	pixel_y = 9
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"RE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	id = "ds2disposals"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/pool,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"RH" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"RP" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"RQ" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/bureaucracy/folder{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/bureaucracy/folder{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/stamp{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/stamp/denied{
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "ds2corpliaison";
+	req_access = list("syndicate_leader");
+	name = "Shutters control";
+	desc = "Keep out the paperwork.";
+	pixel_y = 24;
+	pixel_x = -32
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"RT" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/filingcabinet,
+/obj/item/folder/syndicate/red,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/camera/xray/directional/north{
+	network = list("ds2");
+	c_tag = "DS-2 Vault"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"RV" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"RX" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"RY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"RZ" = (
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Sb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Sc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/survival_pod,
+/obj/item/paper_bin,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/obj/item/pen,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Se" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Sf" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/ds2atmos{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/camera/xray/directional/south{
+	network = list("ds2");
+	c_tag = "DS-2 Bridge"
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Si" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Sj" = (
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"So" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Sp" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/rack/gunrack,
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = -8
+	},
+/obj/item/gun/ballistic/automatic/pistol,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
+"Sq" = (
+/obj/machinery/light/warm/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/trinary/filter/flipped,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Sv" = (
+/obj/machinery/autolathe/hacked,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Sw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/modular_computer/console/preset/curator,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Sx" = (
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/structure/cable,
+/obj/machinery/computer/camera_advanced/syndie,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Sy" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"SB" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"SG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"SH" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"SI" = (
+/obj/machinery/atmospherics/components/binary/pump/off/supply/visible/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"SN" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"SO" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"SR" = (
+/obj/effect/turf_decal/skyrat_decals/syndicate/top/right,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"SX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"SY" = (
+/obj/structure/table/wood,
+/obj/item/storage/photo_album/syndicate{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/stamp/syndicate{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 11;
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"SZ" = (
+/obj/machinery/computer/security{
+	dir = 1;
+	network = list("ds2")
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Ta" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/south,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_y = 9
+	},
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Td" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"Tf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/item/trash/boritos/red{
+	pixel_x = -13;
+	pixel_y = -10
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Tm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/atmos_control/nocontrol/incinerator{
+	dir = 1;
+	atmos_chambers = list("syndieincinerator"="DS-2 Incinerator Chamber")
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"To" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Tp" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Ts" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/railing/corner{
+	dir = 8;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/light/red/directional/south,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Tt" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Tu" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Tw" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade/antiweed{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 11;
+	pixel_y = 11
+	},
+/obj/item/watertank,
+/obj/item/clothing/accessory/armband/hydro{
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "service armband";
+	pixel_x = 15
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"Tx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"TA" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/vending/syndichem,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"TB" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 5;
+	height = 8;
+	name = "DS-2 Hangar";
+	width = 11
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"TG" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"TH" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"TI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"TL" = (
+/obj/item/clothing/suit/hooded/wintercoat/engineering,
+/obj/item/clothing/head/soft/sec/syndicate,
+/obj/item/clothing/under/syndicate/skyrat/overalls,
+/obj/item/clothing/under/syndicate/skyrat/overalls/skirt,
+/obj/item/clothing/under/rank/engineering/engineer/skyrat/utility/syndicate,
+/obj/item/clothing/suit/jacket/gorlex_harness,
+/obj/item/clothing/suit/hazardvest,
+/obj/structure/closet/secure_closet{
+	icon_state = "eng_secure";
+	name = "engine technician gear locker";
+	req_access = list("syndicate")
+	},
+/obj/item/clothing/accessory/armband/engine{
+	name = "engine technician armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	},
+/obj/item/clothing/accessory/armband/engine{
+	name = "engine technician armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	},
+/obj/item/clothing/glasses/hud/ar/aviator/meson,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/item/holosign_creator/atmos{
+	pixel_y = -8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"TM" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/power/rtg/advanced,
+/obj/machinery/light/warm/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"TQ" = (
+/obj/item/storage/box/pillbottles{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/storage/box/medipens{
+	pixel_x = 4;
+	pixel_y = 13
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"TS" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/door/airlock/vault{
+	id_tag = "syndie_ds2_vault"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"TT" = (
+/obj/machinery/button/door/directional/west{
+	desc = "To keep your hangar away from prying eyes.";
+	id = "void-be-gone";
+	name = "Hangar Blast Door Control";
+	req_access = list("syndicate")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"TW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"TX" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"Ua" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Uc" = (
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Ue" = (
+/obj/item/reagent_containers/cup/bucket/wooden,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Uh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
+	},
+/obj/item/wallframe/painting,
+/obj/item/wallframe/painting{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -10
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Ui" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/rag,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_y = 6;
+	pixel_x = 3
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Uj" = (
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	hackProof = 1
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Um" = (
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Un" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/light/warm/directional/east,
+/obj/item/plate{
+	pixel_x = -4
+	},
+/obj/effect/spawner/random/food_or_drink/dinner{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Up" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Us" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"Uv" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Uz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/trimline/dark_blue/corner,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"UB" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ds2bridge"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"UE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"UM" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/syndie/surgery{
+	pixel_y = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"UO" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"UQ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "diner-view"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"UR" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"UT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light/warm/directional/east,
+/obj/machinery/vending/dorms,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"UX" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/survival_pod{
+	req_access = list("syndicate_leader");
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"UY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Va" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	desc = "Keep out the Officers.";
+	id = "smasteratarms";
+	name = "Master at Arms' room bolt";
+	normaldoorcontrol = 1;
+	req_access = list("syndicate_leader");
+	specialfunctions = 4;
+	pixel_x = 6
+	},
+/obj/machinery/button/door/directional/south{
+	desc = "Keep out the Officers.";
+	id = "smasteratarms";
+	name = "Master at Arms' shutters control";
+	req_access = list("syndicate_leader");
+	pixel_x = -6
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Vb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Ve" = (
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/processor,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Vf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Vm" = (
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Vn" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Vo" = (
+/obj/machinery/light/cold/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/west,
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Vp" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Vu" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/chem_mass_spec,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"Vv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden{
+	dir = 9
+	},
+/obj/structure/canister_frame/machine/unfinished_canister_frame,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Vw" = (
+/obj/machinery/gibber,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Vy" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/recharger,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = -9
+	},
+/obj/item/crowbar{
+	pixel_y = -13
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Vz" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"VB" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"VC" = (
+/obj/machinery/camera/directional/north{
+	network = list("ds2");
+	c_tag = "DS-2 Interrogation Room"
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"VE" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"VF" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/red/directional/south,
+/obj/item/circuitboard/machine/ore_silo,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2;
+	icon_state = "box_1"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"VJ" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/template_noop)
+"VK" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"VM" = (
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"VO" = (
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/line{
+	dir = 1
+	},
+/obj/machinery/airalarm/syndicate{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"VP" = (
+/obj/machinery/power/shuttle_engine/large,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/floor{
+	use_power = 0
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"VR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"VT" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"VX" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	name = "Corporate Liaison Shutters";
+	id = "ds2corpliaison";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
+"VY" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/east{
+	desc = "To keep pesky prisoners obedient.";
+	id = "gaybabyjail";
+	name = "Isolation Cell Control";
+	req_access = list("syndicate_leader")
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Wf" = (
+/obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/syndicate{
+	pixel_y = 5
+	},
+/obj/item/circuitboard/machine/rtg/advanced{
+	pixel_y = -2
+	},
+/obj/item/circuitboard/machine/rtg/advanced,
+/obj/item/circuitboard/machine/rtg/advanced{
+	pixel_y = 2
+	},
+/obj/item/circuitboard/machine/rtg/advanced{
+	pixel_y = 5
+	},
+/obj/effect/spawner/random/techstorage/data_disk{
+	pixel_x = -5
+	},
+/obj/item/storage/box/stockparts/deluxe{
+	pixel_y = -4;
+	pixel_x = 3
+	},
+/obj/structure/closet/crate/engineering,
+/obj/item/t_scanner,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/airalarm/syndicate{
+	pixel_y = -24
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Wk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/open/floor/engine/plasma,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Wm" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Wn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Wq" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Ws" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Wt" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Wu" = (
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Long-Term Brig"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "DS2permabrig"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Wv" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/window/survival_pod{
+	req_access = list("syndicate_leader");
+	dir = 8;
+	name = "Isolation Cell"
+	},
+/obj/machinery/door/window/survival_pod{
+	req_access = list("syndicate_leader");
+	dir = 4;
+	name = "Isolation Cell"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "gaybabyjail"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Ww" = (
+/obj/effect/turf_decal/box/red/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"Wx" = (
+/obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/sign/warning/no_smoking/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Wz" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/airalarm/syndicate{
+	pixel_y = -24
+	},
+/turf/open/floor/iron/dark/side,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"WA" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"WC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"WE" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "dorms-view"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"WG" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"WH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"WL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"WM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/vg_decals/atmos/air,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"WN" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_y = 5;
+	pixel_x = -2
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"WS" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"WW" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"WZ" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "eng";
+	name = "electrical supplies locker";
+	req_access = list("syndicate");
+	icon_door = "eng_elec"
+	},
+/obj/item/electronics/airlock{
+	pixel_y = -7;
+	pixel_x = 5
+	},
+/obj/item/electronics/airlock{
+	pixel_y = -7;
+	pixel_x = -5
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -7
+	},
+/obj/item/electronics/apc{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/electronics/firelock{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 2
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -8;
+	pixel_x = -8
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -8;
+	pixel_x = -4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -8
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -8;
+	pixel_x = 4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -8;
+	pixel_x = 8
+	},
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Xb" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Xf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Incinerator Hatch";
+	id_tag = "DS2incineratorHatch"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/holosign/barrier/atmos/sturdy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Xg" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Xh" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"Xk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/lounge)
+"Xl" = (
+/obj/machinery/vending/imported/yangyu,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Xm" = (
+/obj/structure/chair,
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"Xn" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_y = 8
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"Xq" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Xr" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Xt" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "ds2conveyor"
+	},
+/obj/machinery/light/red/directional/south,
+/obj/structure/plasticflaps,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Xy" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Xz" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"XA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/enginetech{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"XC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/crate/solarpanel_small,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"XF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"XG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"XI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access = list("syndicate")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"XN" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/machinery/computer/monitor{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"XP" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"XR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"XV" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"XX" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"XY" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/power/apc/auto_name/directional/west{
+	req_access = list("syndicate")
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
+"Ya" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/structure/sign/flag/syndicate/directional/south{
+	pixel_x = -16
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/coffeemaker,
+/turf/open/floor/iron/dark/textured_half,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"Yb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/floor{
+	use_power = 0
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
+"Yd" = (
+/obj/machinery/power/turbine/turbine_outlet,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Ye" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_y = 4
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -6
+	},
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
+"Yn" = (
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Yp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Yz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/skill_station,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"YC" = (
+/obj/machinery/air_sensor{
+	chamber_id = "syndieincinerator"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"YD" = (
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"YG" = (
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate_command/admiral,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"YH" = (
+/obj/machinery/door/airlock/silver{
+	name = "Public Showers"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"YI" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
+"YK" = (
+/obj/item/circuitboard/computer/mech_bay_power_console,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/structure/frame/computer,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"YN" = (
+/obj/machinery/vending/wardrobe/syndie_wardrobe,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"YQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"YR" = (
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/camera/xray/directional/west{
+	network = list("ds2");
+	c_tag = "DS-2 Research"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
+"Zd" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Zg" = (
+/obj/machinery/suit_storage_unit/syndicate/softsuit,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
+"Zh" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "ds2conveyor"
+	},
+/obj/machinery/door/poddoor{
+	id = "ds2cargo"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Zi" = (
+/obj/effect/turf_decal/trimline/purple/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Zo" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"Zp" = (
+/obj/machinery/iv_drip,
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Zq" = (
+/obj/structure/sign/flag/syndicate/directional/south,
+/obj/machinery/light/warm/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
+"Zs" = (
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/turf/open/floor/iron/white/small,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Zt" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/food_or_drink/salad{
+	pixel_y = 3
+	},
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
+"Zz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESRedguard";
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"ZA" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 6
+	},
+/obj/item/toy/mecha/mauler{
+	pixel_y = 16
+	},
+/obj/item/toy/mecha/deathripley{
+	pixel_x = -16;
+	pixel_y = 8
+	},
+/obj/item/toy/figure/syndie,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"ZB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/diagonal,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"ZC" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"ZE" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/machinery/light/red/directional/west,
+/obj/machinery/turretid{
+	ailock = 1;
+	control_area = "/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault";
+	dir = 1;
+	icon_state = "control_kill";
+	lethal = 1;
+	name = "DS2 turret controls";
+	req_access = list("syndicate");
+	pixel_x = -30
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
+"ZF" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"ZH" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"ZP" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"ZQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo)
+"ZS" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"ZT" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
+"ZY" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/skyrat/interdynefob)
 
 (1,1,1) = {"
-wgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwg
-wgwgwgwgwgwgwgEJwgwgwgwgwgNBNcICwgMtwgwgwgwgwgwgwgwgwgwgwgwgwgnOwgICNcNBNcICNcICwgwgwgwgwgEJwgwgwgwgwgwg
-wgwgwgwgwgwgwgkxwgwgxrdTcINBzIOiqzNBwgwgwgwgwgwgwgwgwgwgwgwgwgNBdTzIOiNBzIOizIOidTcIxrwgwgkxwgwgwgwgwgwg
-wgwgwgwgwgwgwgNBwgxrNBqhqhNBqhqhqhNBxrwgwgwgwgwgwgwgwgwgwgwgxrNBqhqhqhNBqhqhqhqhqhqhNBxrwgMtwgwgwgwgwgwg
-wgwgwgwgwgwgxrNBNBNBNBNBNBNBNBNBNBNBNBwgwgEJwgwgVJwgwgEJwgwgNBNBNBNBNBNBNBNBbwbwbwbwbwbwbwbwgnwgwgwgwgwg
-wgwgwgwgwgwgIQtgFwIQZFVOEVrIELonjfQpcmiEiEkgiEiEBsiEiEkgiEiEcmEcfoSwekdaekRdbwrULTbwzVXVzVzVUQwgwgwgwgwg
-wgwgwgwgwgwgIQCjFHYHDKililvDNOFjFjaLvawgwgkxwgwgkxwgwgkxwgwgvazdTWsHWnHbGYrioVmeVmbwMwQarMUnUQwgwgwgwgwg
-wgwgwgwgwgwgIQrsdRIQPYnyAXqYELonFjRhHHwgwgBkUBUBUBUBUBBkwgwgHHoZTWsHScmKUhsBbwbwbwbwyyQaEUQBUQwgwgwgwgwg
-wgwgwgwgwgwgKfKfKfKfKfKfKfKfKfyPFjOpHHwgaTBkqIAvouSxHtBkaTwgHHYzYQsHXkRxEyGSpOiYZtchWAFiChpIbwwgwgwgwgwg
-wgwgwgwgwgwgKfiRptscKfwjEPYNcUsOFjcPBkBkBkXNlDWNdDDFPtmYBkBkBkmOFjnHGgnIMMGtgOFYFYFYpzNrkcxkbwwgwgwgwgwg
-wgwgwgwgwgwgKfeoeWttKfdoNmrjcUNWFjndUBMZluAVAVOPwJSRAVJSVMfEUBAfFjqSwhjthJJIpOQaQaQaRrMkHwOdbwwgwgwgwgwg
-wgwgwgwgwgwgKfKfZzKfKfnnDBDJokHEzbpnUjHqfafayIsycjjCKeKeKeUpNkCqFjRclOlOlOlOlOXlaBqRRrkGHwUibwwgwgwgwgwg
-wgwgwgwgwgwgWEPeKYxHNGJELfZPcULzFjNTUBsMdOofVnsawuKdObofdOySUBzAFjovlOXYBCuhlOIwIwlOtZAZropObwgvwgwgwgwg
-wgwgEJwgwgwgWENedhUTKfKfuiKfKfXRzbZdRXRXakRXACYaSfeDZAEYdQEYEYXrzbQClObdQQQQQoQQufNojTjTePsZqabwwgwgwgwg
-wgwgkxwgICNcKfKfiKKfKfqskmKfGGLzvMRXRXFDhiRXRXRXEYEYEYEYLGdFEYEYwHqvIwmicDPWmTTwDHkDWLCfzquAqHbwgnwgwgwg
-wgwgNBqzzIOiKfAzgbDEKfqceUKfpsLzLoVXjpRQJLlgCmdCEYAtYGvxUsjBNXMEFjUmIwXzRbFxFxFxVBlOWsCfXytTjjHrbwwgwgwg
-wgwgNBqhqhqhKfiRiZttKfQOiRKfGGLzIhkNQWjDJLQszHcGEYbtCHIZUsSYGVMEFjaRqCPSWGwewewekIlORzGlobSGaCBtbwwgwgwg
-wgmXkFkFkFkFkFkFuVuVuVuVuVuVuVynLoVXzDLQLKvvuBINEYjrLeXIZqhhMCMEFjYnIwiPGUFxFxFxeOlOepMFDSSXCfHhbwwgwgwg
-mXkFEwOeQxpXDzyHuVitkbxyVCeEtYoOSjRtRtRtRtRtRtRtRtRtRtRtvlvlvlvlRmKjaPvOWWwewewekIlOoTKgxSKGCfBjbwwgwgwg
-kFrHgAkQPouSGhNSuVQHYeAKIiBVcLogFjRtbRvgZHztMBTQRtnzumRtuEBiRTvlFjOFDLFJatFxFxFxVBlOeelEPUSNVwwVbwwgwgwg
-kFGLVpkQabkFkFkFuVRePfAWmjsLtYubFjRtjbuuUMAoyUZsRtZpotRtZEsKhyTSloOUHzHzHzHzHzHzHzHzHzHzHzHzHzHzHzwgwgwg
-kFnSNikQgiPybxhaXhXhXhXhXhXhXhBSwpRtuWuutLMGyUWtRtcYnRRtadVFuevlvQZiHztmQMNlLBPAKTHzYKajpevdjJHzkxwgwgwg
-kFfyTfwEEZdvxZTHXhFPvKaYvrqjFkLzUzRtQYCbyekHfhliRtcuRtRtvlvlvlvlyvagFmRHpuJvGzHIKutCvBwmcSmrlYHzkxwgwgwg
-kFURURDhURkFkFkFXhwzxXJDqNieFkLzAIyahHAwMoMoCpEQhqCdtUcAcAhETAJdiyfBHzzUfAjlDmoKboFzSBeFlFDtjWHzkxwgwgwg
-kFXmtRbsVYkFavUeXhafrzVawNorFkLzmxRthTMnMnPVToToQNgWDyVuibIaowJdazzSHzYRfAsPqKGxvoFzgwflAafwqoHzwgwgwgwg
-kFJlRZkQGiWvshwcXhydLxXhXhXhXhynmxoCFAyXlWTGhHYpfdQzioiXYDZTFOTXazfBFzqWczSOOkFBnGHzpkbYwnWzJKHzwgwgwgwg
-kFiVvckQhPkFkFkFXhjdeYbqRpoSXhLzmxoCOxiFaoIAgBZBdnJRUOocZSHAsVTXazfBFzijWCIHbXTawkHzHzHzHzHzHzHzwgwgwgwg
-kFtSkMkQsDkFDsQiXhznrrNPWqgKXhubaFRtoCoCRtRtRtmdoCByJdJdJdTXTXJdjcQhFzzgWCplHzHzHzaWzcNspyLbzcaWkxEJwgwg
-kFuNVpkQtnraXbqnXhltrrOCtfpWXhLzlUJFSoSoyuSohfdZdZcnUEfSyuSoSoyiJNVExGMgMPcOHzxQeHtQtQtQtQwtxQhMwgwgwgwg
-kFuNVpkQmPkFbuvFXhOvGeFhYINYXhkfzpxpzpZCbAtqtqvEdztkXqXqJyXgDvpaqtrkHzSvixrxHzeHHDQGnmnmmQRVwthMkxkxkxEJ
-kFjZVpkQDrkFkFkFXhXhjOSHRfRfXhDkUXmsmsKNTtJzJzTtgxTtJzJzmyaujmmySbjwmymymymymyTpQGnmnmnmnmmQsrhMwgwgwgwg
-kFkFxxEnFohCkFaayLXhCCWScrbyvThoFeHazlNQTtLszMCXNNLVeAdNmyTTMTVyWmkZihgGAnJCrNTpnmnmnmnmnmnmsrhMEJwgwgwg
-kxkFrciORuLwgjFbhzpBnTrlozrlzNpitfmslpBeTtTLPOCeKSXAeXHFmyUcbjmHzKFZvAKktGDwtGiznmnmnmnmnmnmsrhMsswgwgwg
-kxkFrcVTRuOTkFBNGOmsxcrrpfxuxuxuPRgFBOXFTtWZrZLlHZffVzRjmytDSZpPNLSyqOEjmymymyTBnmnmnmnmnmnmsrhMaJwgwgwg
-kxkFrcIrRuVbAePPhsWuvprlXhaHKbVKTtTtTtTtTtTtOclZmCnKImTtmyjmjmmydrXXdsCENRLMaxbanmnmnmnmnmnmsrhMzvwgwgwg
-kFkFyhDuuLhAkFlJslXhniFhXhrYCtMKTtzLheSIWMTtPqeTnAEBdgTtCFBvBGmyQwgordHKHVZhXtTpnmnmnmnmnmnmsrhMEJwgwgwg
-kFveveveRPGDkFkFPXPXtPFyPXTtTtTtTtdSaXrbkarGsjFaJBHnPxTtmDcyFGKCTuFZZojmjmmymyTpfcnmnmnmnmRasrhMwgwgwgwg
-kFQVbPCTXGArfeLrPXLvmAbkAGTtBbVfoiQFnNhnzyTtkdTmeKquktTtfQrBmJfWZQFZGbDAXCcqmyWwNbfcnmnmRaKIjRhMkxkxkxEJ
-kFucAlJAXGLPLPdIPXbSuoLqIUTtiBFlaZtNemuDhGJzIogkUYhZpbTtcWeJcWmyPMFZIVaeldKQtGxQWwststjNstjRxQhMwgwgwgwg
-kFKMahUaiMyROyctPXHcuoLqoRTtJzJzTtnLaNuDEzJzOKFCQePiETTtmymymymyVoRYRYcacaQKmlQEARBwjECVCStETsMtkxEJwgwg
-mXkFSeVeHuJfBLlbPXSpuoLqacTtEbdyFcVvkeodVRJzODLATMKzBmTtXnKJMHfzxbFZWHKhiwAumymymyMtlIGXxdGdAxAxwgwgwgwg
-wgmXkFkFkFkFkFkFPXECLYEdBuTtONNCJzTxxBiSSqTtCnCnTtkTRETtqEvqoEDIsWFZWHGRGEKVzhcbmyAxAxAxAxAxAxAywgwgwgwg
-wgwgNBzXzXzXzXXPPXPXoGLqqwTtJzJzTtWxketAzxCnQbwSCnjPtlTthgrgZghRhFFZWHIMcErDmymymyTdzXzXzXzXNBwgwgwgwgwg
-wgwgNBOiOiOiOiOizXzXPXpLgyTtNgWkSiPnmgTIezXfYCgNCnbWvRTtZgEWZghRoqEmDeFZFZCymyzXzXOiOiOiOiOiNBwgwgwgwgwg
-wgwgNBuqYbOiOiOiOiOiPXPXPXTtLgvUTtTtTtTtTtTtTthxTtggTtTtfzfzfzfzmymyhQQAWfGHmyOiOiOiOiOiVPZYNBwgwgwgwgwg
-wgwgNBwgwgGKYbZYVPZYNBNBNBNBNBNBNBbnzXzXzXzXTtGkNAJZTtzXzXzXzXCJmymymymymymymyuqYbGKYbZYwgwgNBwgwgwgwgwg
-wgwgkxwgwgwgwgwgwgwgNBNBzXzXzXzXzXOiOiOiOiOiTtYdTtzeTtOiOiOiOiOizXzXzXzXzXNBNBwgwgwgwgwgwgwgkxwgwgwgwgwg
-wgwgEJwgwgwgwgwgwgwgxrNBOiOiOiOiOiOiOiOiVPZYTtprTtbeTtuqYbOiOiOiOiOiOiOiOiNBxrwgwgwgwgwgwgwgEJwgwgwgwgwg
-wgwgwgwgwgwgwgwgwgwgwgNBuqYbOiOiOiGKYbZYwgwgvSkxkxUvvSwgwgGKYbZYOiOiOiVPZYNBwgwgwgwgwgwgwgwgwgwgwgwgwgwg
-wgwgwgwgwgwgwgwgwgwgwgNBwgwgGKYbZYwgwgwgwgwgkxwgwgwgkxwgwgwgwgwgGKYbZYwgwgNBwgwgwgwgwgwgwgwgwgwgwgwgwgwg
-wgwgwgwgwgwgwgwgwgwgwgkxwgwgwgwgwgwgwgwgwgwgEJwgwgwgEJwgwgwgwgwgwgwgwgwgwgkxwgwgwgwgwgwgwgwgwgwgwgwgwgwg
-wgwgwgwgwgwgwgwgwgwgwgEJwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgEJwgwgwgwgwgwgwgwgwgwgwgwgwgwg
-wgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwgwg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+mX
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kx
+kx
+kx
+kF
+kF
+kF
+kF
+kF
+mX
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(2,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+mX
+kF
+rH
+GL
+nS
+fy
+UR
+Xm
+Jl
+iV
+tS
+uN
+uN
+jZ
+kF
+kF
+kF
+kF
+kF
+ve
+QV
+uc
+KM
+kF
+mX
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(3,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+EJ
+kx
+NB
+NB
+kF
+Ew
+gA
+Vp
+Ni
+Tf
+UR
+tR
+RZ
+vc
+kM
+Vp
+Vp
+Vp
+xx
+rc
+rc
+rc
+yh
+ve
+bP
+Al
+ah
+Se
+kF
+NB
+NB
+NB
+NB
+kx
+EJ
+wg
+wg
+wg
+wg
+wg
+"}
+(4,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+qz
+qh
+kF
+Oe
+kQ
+kQ
+kQ
+wE
+Dh
+bs
+kQ
+kQ
+kQ
+kQ
+kQ
+kQ
+En
+iO
+VT
+Ir
+Du
+ve
+CT
+JA
+Ua
+Ve
+kF
+zX
+Oi
+uq
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(5,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+IC
+zI
+qh
+kF
+Qx
+Po
+ab
+gi
+EZ
+UR
+VY
+Gi
+hP
+sD
+tn
+mP
+Dr
+Fo
+Ru
+Ru
+Ru
+uL
+RP
+XG
+XG
+iM
+Hu
+kF
+zX
+Oi
+Yb
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(6,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+Nc
+Oi
+qh
+kF
+pX
+uS
+kF
+Py
+dv
+kF
+kF
+Wv
+kF
+kF
+ra
+kF
+kF
+hC
+Lw
+OT
+Vb
+hA
+GD
+Ar
+LP
+yR
+Jf
+kF
+zX
+Oi
+Oi
+GK
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(7,1,1) = {"
+wg
+wg
+wg
+wg
+xr
+IQ
+IQ
+IQ
+Kf
+Kf
+Kf
+Kf
+WE
+WE
+Kf
+Kf
+Kf
+kF
+Dz
+Gh
+kF
+bx
+xZ
+kF
+av
+sh
+kF
+Ds
+Xb
+bu
+kF
+kF
+gj
+kF
+Ae
+kF
+kF
+fe
+LP
+Oy
+BL
+kF
+zX
+Oi
+Oi
+Yb
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(8,1,1) = {"
+wg
+EJ
+kx
+NB
+NB
+tg
+Cj
+rs
+Kf
+iR
+eo
+Kf
+Pe
+Ne
+Kf
+Az
+iR
+kF
+yH
+NS
+kF
+ha
+TH
+kF
+Ue
+wc
+kF
+Qi
+qn
+vF
+kF
+aa
+Fb
+BN
+PP
+lJ
+kF
+Lr
+dI
+ct
+lb
+kF
+XP
+Oi
+Oi
+ZY
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(9,1,1) = {"
+wg
+wg
+wg
+wg
+NB
+Fw
+FH
+dR
+Kf
+pt
+eW
+Zz
+KY
+dh
+iK
+gb
+iZ
+uV
+uV
+uV
+uV
+Xh
+Xh
+Xh
+Xh
+Xh
+Xh
+Xh
+Xh
+Xh
+Xh
+yL
+hz
+GO
+hs
+sl
+PX
+PX
+PX
+PX
+PX
+PX
+PX
+zX
+Oi
+VP
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(10,1,1) = {"
+wg
+wg
+wg
+xr
+NB
+IQ
+YH
+IQ
+Kf
+sc
+tt
+Kf
+xH
+UT
+Kf
+DE
+tt
+uV
+it
+QH
+Re
+Xh
+FP
+wz
+af
+yd
+jd
+zn
+lt
+Ov
+Xh
+Xh
+pB
+ms
+Wu
+Xh
+PX
+Lv
+bS
+Hc
+Sp
+EC
+PX
+zX
+Oi
+ZY
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(11,1,1) = {"
+wg
+wg
+xr
+NB
+NB
+ZF
+DK
+PY
+Kf
+Kf
+Kf
+Kf
+NG
+Kf
+Kf
+Kf
+Kf
+uV
+kb
+Ye
+Pf
+Xh
+vK
+xX
+rz
+Lx
+eY
+rr
+rr
+Ge
+jO
+CC
+nT
+xc
+vp
+ni
+tP
+mA
+uo
+uo
+uo
+LY
+oG
+PX
+PX
+NB
+NB
+xr
+wg
+wg
+wg
+wg
+wg
+"}
+(12,1,1) = {"
+wg
+wg
+dT
+qh
+NB
+VO
+il
+ny
+Kf
+wj
+do
+nn
+JE
+Kf
+qs
+qc
+QO
+uV
+xy
+AK
+AW
+Xh
+aY
+JD
+Va
+Xh
+bq
+NP
+OC
+Fh
+SH
+WS
+rl
+rr
+rl
+Fh
+Fy
+bk
+Lq
+Lq
+Lq
+Ed
+Lq
+pL
+PX
+NB
+NB
+NB
+NB
+NB
+kx
+EJ
+wg
+"}
+(13,1,1) = {"
+wg
+wg
+cI
+qh
+NB
+EV
+il
+AX
+Kf
+EP
+Nm
+DB
+Lf
+ui
+km
+eU
+iR
+uV
+VC
+Ii
+mj
+Xh
+vr
+qN
+wN
+Xh
+Rp
+Wq
+tf
+YI
+Rf
+cr
+oz
+pf
+Xh
+Xh
+PX
+AG
+IU
+oR
+ac
+Bu
+qw
+gy
+PX
+NB
+zX
+Oi
+uq
+wg
+wg
+wg
+wg
+"}
+(14,1,1) = {"
+wg
+NB
+NB
+NB
+NB
+rI
+vD
+qY
+Kf
+YN
+rj
+DJ
+ZP
+Kf
+Kf
+Kf
+Kf
+uV
+eE
+BV
+sL
+Xh
+qj
+ie
+or
+Xh
+oS
+gK
+pW
+NY
+Rf
+by
+rl
+xu
+aH
+rY
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+NB
+zX
+Oi
+Yb
+wg
+wg
+wg
+wg
+"}
+(15,1,1) = {"
+wg
+Nc
+zI
+qh
+NB
+EL
+NO
+EL
+Kf
+cU
+cU
+ok
+cU
+Kf
+GG
+ps
+GG
+uV
+tY
+cL
+tY
+Xh
+Fk
+Fk
+Fk
+Xh
+Xh
+Xh
+Xh
+Xh
+Xh
+vT
+zN
+xu
+Kb
+Ct
+Tt
+Bb
+iB
+Jz
+Eb
+ON
+Jz
+Ng
+Lg
+NB
+zX
+Oi
+Oi
+GK
+wg
+wg
+wg
+"}
+(16,1,1) = {"
+wg
+IC
+Oi
+qh
+NB
+on
+Fj
+on
+yP
+sO
+NW
+HE
+Lz
+XR
+Lz
+Lz
+Lz
+yn
+oO
+og
+ub
+BS
+Lz
+Lz
+Lz
+yn
+Lz
+ub
+Lz
+kf
+Dk
+ho
+pi
+xu
+VK
+MK
+Tt
+Vf
+Fl
+Jz
+dy
+NC
+Jz
+Wk
+vU
+NB
+zX
+Oi
+Oi
+Yb
+wg
+wg
+wg
+"}
+(17,1,1) = {"
+wg
+wg
+qz
+qh
+NB
+jf
+Fj
+Fj
+Fj
+Fj
+Fj
+zb
+Fj
+zb
+vM
+Lo
+Ih
+Lo
+Sj
+Fj
+Fj
+wp
+Uz
+AI
+mx
+mx
+mx
+aF
+lU
+zp
+UX
+Fe
+tf
+PR
+Tt
+Tt
+Tt
+oi
+aZ
+Tt
+Fc
+Jz
+Tt
+Si
+Tt
+NB
+zX
+Oi
+Oi
+ZY
+wg
+wg
+wg
+"}
+(18,1,1) = {"
+wg
+Mt
+NB
+NB
+NB
+Qp
+aL
+Rh
+Op
+cP
+nd
+pn
+NT
+Zd
+RX
+VX
+kN
+VX
+Rt
+Rt
+Rt
+Rt
+Rt
+ya
+Rt
+oC
+oC
+Rt
+JF
+xp
+ms
+Ha
+ms
+gF
+Tt
+zL
+dS
+QF
+tN
+nL
+Vv
+Tx
+Wx
+Pn
+Tt
+bn
+Oi
+Oi
+GK
+wg
+wg
+wg
+wg
+"}
+(19,1,1) = {"
+wg
+wg
+wg
+xr
+NB
+cm
+va
+HH
+HH
+Bk
+UB
+Uj
+UB
+RX
+RX
+jp
+QW
+zD
+Rt
+bR
+jb
+uW
+QY
+hH
+hT
+FA
+Ox
+oC
+So
+zp
+ms
+zl
+lp
+BO
+Tt
+he
+aX
+nN
+em
+aN
+ke
+xB
+ke
+mg
+Tt
+zX
+Oi
+Oi
+Yb
+wg
+wg
+wg
+wg
+"}
+(20,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+wg
+wg
+Bk
+MZ
+Hq
+sM
+RX
+FD
+RQ
+jD
+LQ
+Rt
+vg
+uu
+uu
+Cb
+Aw
+Mn
+yX
+iF
+oC
+So
+ZC
+KN
+NQ
+Be
+XF
+Tt
+SI
+rb
+hn
+uD
+uD
+od
+iS
+tA
+TI
+Tt
+zX
+Oi
+Oi
+ZY
+wg
+wg
+wg
+wg
+"}
+(21,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+wg
+aT
+Bk
+lu
+fa
+dO
+ak
+hi
+JL
+JL
+LK
+Rt
+ZH
+UM
+tL
+ye
+Mo
+Mn
+lW
+ao
+Rt
+yu
+bA
+Tt
+Tt
+Tt
+Tt
+Tt
+WM
+ka
+zy
+hG
+Ez
+VR
+Sq
+zx
+ez
+Tt
+zX
+Oi
+VP
+wg
+wg
+wg
+wg
+wg
+"}
+(22,1,1) = {"
+wg
+wg
+wg
+wg
+EJ
+kg
+kx
+Bk
+Bk
+XN
+AV
+fa
+of
+RX
+RX
+lg
+Qs
+vv
+Rt
+zt
+Ao
+MG
+kH
+Mo
+PV
+TG
+IA
+Rt
+So
+tq
+Jz
+Ls
+TL
+WZ
+Tt
+Tt
+rG
+Tt
+Jz
+Jz
+Jz
+Tt
+Cn
+Xf
+Tt
+zX
+Oi
+ZY
+wg
+wg
+wg
+wg
+wg
+"}
+(23,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+UB
+qI
+lD
+AV
+yI
+Vn
+AC
+RX
+Cm
+zH
+uB
+Rt
+MB
+yU
+yU
+fh
+Cp
+To
+hH
+gB
+Rt
+hf
+tq
+Jz
+zM
+PO
+rZ
+Oc
+Pq
+sj
+kd
+Io
+OK
+OD
+Cn
+Qb
+YC
+Tt
+Tt
+Tt
+Tt
+vS
+kx
+EJ
+wg
+wg
+"}
+(24,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+UB
+Av
+WN
+OP
+sy
+sa
+Ya
+RX
+dC
+cG
+IN
+Rt
+TQ
+Zs
+Wt
+li
+EQ
+To
+Yp
+ZB
+md
+dZ
+vE
+Tt
+CX
+Ce
+Ll
+lZ
+eT
+Fa
+Tm
+gk
+FC
+LA
+Cn
+wS
+gN
+hx
+Gk
+Yd
+pr
+kx
+wg
+wg
+wg
+wg
+"}
+(25,1,1) = {"
+wg
+wg
+wg
+wg
+VJ
+Bs
+kx
+UB
+ou
+dD
+wJ
+cj
+wu
+Sf
+EY
+EY
+EY
+EY
+Rt
+Rt
+Rt
+Rt
+Rt
+hq
+QN
+fd
+dn
+oC
+dZ
+dz
+gx
+NN
+KS
+HZ
+mC
+nA
+JB
+eK
+UY
+Qe
+TM
+Tt
+Cn
+Cn
+Tt
+NA
+Tt
+Tt
+kx
+wg
+wg
+wg
+wg
+"}
+(26,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+UB
+Sx
+DF
+SR
+jC
+Kd
+eD
+EY
+At
+bt
+jr
+Rt
+nz
+Zp
+cY
+cu
+Cd
+gW
+Qz
+JR
+By
+cn
+tk
+Tt
+LV
+XA
+ff
+nK
+EB
+Hn
+qu
+hZ
+Pi
+Kz
+kT
+jP
+bW
+gg
+JZ
+ze
+be
+Uv
+wg
+wg
+wg
+wg
+"}
+(27,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+UB
+Ht
+Pt
+AV
+Ke
+Ob
+ZA
+EY
+YG
+CH
+Le
+Rt
+um
+ot
+nR
+Rt
+tU
+Dy
+io
+UO
+Jd
+UE
+Xq
+Jz
+eA
+eX
+Vz
+Im
+dg
+Px
+kt
+pb
+ET
+Bm
+RE
+tl
+vR
+Tt
+Tt
+Tt
+Tt
+vS
+kx
+EJ
+wg
+wg
+"}
+(28,1,1) = {"
+wg
+wg
+wg
+wg
+EJ
+kg
+kx
+Bk
+Bk
+mY
+JS
+Ke
+of
+EY
+EY
+vx
+IZ
+XI
+Rt
+Rt
+Rt
+Rt
+Rt
+cA
+Vu
+iX
+oc
+Jd
+fS
+Xq
+Jz
+dN
+HF
+Rj
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+Tt
+zX
+Oi
+uq
+wg
+wg
+wg
+wg
+wg
+"}
+(29,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+wg
+aT
+Bk
+VM
+Ke
+dO
+dQ
+LG
+Us
+Us
+Zq
+vl
+uE
+ZE
+ad
+vl
+cA
+ib
+YD
+ZS
+Jd
+yu
+Jy
+my
+my
+my
+my
+my
+CF
+mD
+fQ
+cW
+my
+Xn
+qE
+hg
+Zg
+fz
+zX
+Oi
+Yb
+wg
+wg
+wg
+wg
+wg
+"}
+(30,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+iE
+wg
+wg
+wg
+Bk
+fE
+Up
+yS
+EY
+dF
+jB
+SY
+hh
+vl
+Bi
+sK
+VF
+vl
+hE
+Ia
+ZT
+HA
+TX
+So
+Xg
+au
+TT
+Uc
+tD
+jm
+Bv
+cy
+rB
+eJ
+my
+KJ
+vq
+rg
+EW
+fz
+zX
+Oi
+Oi
+GK
+wg
+wg
+wg
+wg
+"}
+(31,1,1) = {"
+wg
+wg
+wg
+xr
+NB
+cm
+va
+HH
+HH
+Bk
+UB
+Nk
+UB
+EY
+EY
+NX
+GV
+MC
+vl
+RT
+hy
+ue
+vl
+TA
+ow
+FO
+sV
+TX
+So
+Dv
+jm
+MT
+bj
+SZ
+jm
+BG
+FG
+mJ
+cW
+my
+MH
+oE
+Zg
+Zg
+fz
+zX
+Oi
+Oi
+Yb
+wg
+wg
+wg
+wg
+"}
+(32,1,1) = {"
+wg
+nO
+NB
+NB
+NB
+Ec
+zd
+oZ
+Yz
+mO
+Af
+Cq
+zA
+Xr
+EY
+ME
+ME
+ME
+vl
+vl
+TS
+vl
+vl
+Jd
+Jd
+TX
+TX
+Jd
+yi
+pa
+my
+Vy
+mH
+pP
+my
+my
+KC
+fW
+my
+my
+fz
+DI
+hR
+hR
+fz
+CJ
+Oi
+Oi
+ZY
+wg
+wg
+wg
+wg
+"}
+(33,1,1) = {"
+wg
+wg
+dT
+qh
+NB
+fo
+TW
+TW
+YQ
+Fj
+Fj
+Fj
+Fj
+zb
+wH
+Fj
+Fj
+Fj
+Rm
+Fj
+lo
+vQ
+yv
+iy
+az
+az
+az
+jc
+JN
+qt
+Sb
+Wm
+zK
+NL
+dr
+Qw
+Tu
+ZQ
+PM
+Vo
+xb
+sW
+hF
+oq
+my
+my
+zX
+Oi
+Oi
+GK
+wg
+wg
+wg
+"}
+(34,1,1) = {"
+wg
+IC
+zI
+qh
+NB
+Sw
+sH
+sH
+sH
+nH
+qS
+Rc
+ov
+QC
+qv
+Um
+aR
+Yn
+Kj
+OF
+OU
+Zi
+ag
+fB
+zS
+fB
+fB
+Qh
+VE
+rk
+jw
+kZ
+FZ
+Sy
+XX
+go
+FZ
+FZ
+FZ
+RY
+FZ
+FZ
+FZ
+Em
+my
+my
+zX
+Oi
+Oi
+Yb
+wg
+wg
+wg
+"}
+(35,1,1) = {"
+wg
+Nc
+Oi
+qh
+NB
+ek
+Wn
+Sc
+Xk
+Gg
+wh
+lO
+lO
+lO
+Iw
+Iw
+qC
+Iw
+aP
+DL
+Hz
+Hz
+Fm
+Hz
+Hz
+Fz
+Fz
+Fz
+xG
+Hz
+my
+ih
+vA
+qO
+ds
+rd
+Zo
+Gb
+IV
+RY
+WH
+WH
+WH
+De
+hQ
+my
+zX
+Oi
+Oi
+ZY
+wg
+wg
+wg
+"}
+(36,1,1) = {"
+wg
+NB
+NB
+NB
+NB
+da
+Hb
+mK
+Rx
+nI
+jt
+lO
+XY
+bd
+mi
+Xz
+PS
+iP
+vO
+FJ
+Hz
+tm
+RH
+zU
+YR
+qW
+ij
+zg
+Mg
+Sv
+my
+gG
+Kk
+Ej
+CE
+HK
+jm
+DA
+ae
+ca
+Kh
+GR
+IM
+FZ
+QA
+my
+zX
+Oi
+VP
+wg
+wg
+wg
+wg
+"}
+(37,1,1) = {"
+wg
+Nc
+zI
+qh
+NB
+ek
+GY
+Uh
+Ey
+MM
+hJ
+lO
+BC
+QQ
+cD
+Rb
+WG
+GU
+WW
+at
+Hz
+QM
+pu
+fA
+fA
+cz
+WC
+WC
+MP
+ix
+my
+An
+tG
+my
+NR
+HV
+jm
+XC
+ld
+ca
+iw
+GE
+cE
+FZ
+Wf
+my
+zX
+Oi
+ZY
+wg
+wg
+wg
+wg
+"}
+(38,1,1) = {"
+wg
+IC
+Oi
+qh
+NB
+Rd
+ri
+sB
+GS
+Gt
+JI
+lO
+uh
+QQ
+PW
+Fx
+we
+Fx
+we
+Fx
+Hz
+Nl
+Jv
+jl
+sP
+SO
+IH
+pl
+cO
+rx
+my
+JC
+Dw
+my
+LM
+Zh
+my
+cq
+KQ
+QK
+Au
+KV
+rD
+Cy
+GH
+my
+NB
+NB
+NB
+NB
+kx
+EJ
+wg
+"}
+(39,1,1) = {"
+wg
+Nc
+zI
+qh
+bw
+bw
+oV
+bw
+pO
+gO
+pO
+lO
+lO
+Qo
+mT
+Fx
+we
+Fx
+we
+Fx
+Hz
+LB
+Gz
+Dm
+qK
+Ok
+bX
+Hz
+Hz
+Hz
+my
+rN
+tG
+my
+ax
+Xt
+my
+my
+tG
+ml
+my
+zh
+my
+my
+my
+my
+NB
+xr
+wg
+wg
+wg
+wg
+wg
+"}
+(40,1,1) = {"
+wg
+IC
+Oi
+qh
+bw
+rU
+me
+bw
+iY
+FY
+Qa
+Xl
+Iw
+QQ
+Tw
+Fx
+we
+Fx
+we
+Fx
+Hz
+PA
+HI
+oK
+Gx
+FB
+Ta
+Hz
+xQ
+eH
+Tp
+Tp
+iz
+TB
+ba
+Tp
+Tp
+Ww
+xQ
+QE
+my
+cb
+my
+zX
+Oi
+uq
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(41,1,1) = {"
+wg
+wg
+dT
+qh
+bw
+LT
+Vm
+bw
+Zt
+FY
+Qa
+aB
+Iw
+uf
+DH
+VB
+kI
+eO
+kI
+VB
+Hz
+KT
+Ku
+bo
+vo
+nG
+wk
+Hz
+eH
+HD
+QG
+nm
+nm
+nm
+nm
+nm
+fc
+Nb
+Ww
+AR
+my
+my
+my
+zX
+Oi
+Yb
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(42,1,1) = {"
+wg
+wg
+cI
+qh
+bw
+bw
+bw
+bw
+ch
+FY
+Qa
+qR
+lO
+No
+kD
+lO
+lO
+lO
+lO
+lO
+Hz
+Hz
+tC
+Fz
+Fz
+Hz
+Hz
+aW
+tQ
+QG
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+fc
+st
+Bw
+Mt
+Ax
+Td
+Oi
+Oi
+GK
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(43,1,1) = {"
+wg
+wg
+xr
+NB
+bw
+zV
+Mw
+yy
+WA
+pz
+Rr
+Rr
+tZ
+jT
+WL
+Ws
+Rz
+ep
+oT
+ee
+Hz
+YK
+vB
+SB
+gw
+pk
+Hz
+zc
+tQ
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+st
+jE
+lI
+Ax
+zX
+Oi
+Oi
+Yb
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(44,1,1) = {"
+wg
+wg
+wg
+xr
+bw
+XV
+Qa
+Qa
+Fi
+Nr
+Mk
+kG
+AZ
+jT
+Cf
+Cf
+Gl
+MF
+Kg
+lE
+Hz
+aj
+wm
+eF
+fl
+bY
+Hz
+Ns
+tQ
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+jN
+CV
+GX
+Ax
+zX
+Oi
+Oi
+ZY
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(45,1,1) = {"
+wg
+wg
+wg
+wg
+bw
+zV
+rM
+EU
+Ch
+kc
+Hw
+Hw
+ro
+eP
+zq
+Xy
+ob
+DS
+xS
+PU
+Hz
+pe
+cS
+lF
+Aa
+wn
+Hz
+py
+tQ
+mQ
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+Ra
+st
+CS
+xd
+Ax
+zX
+Oi
+VP
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(46,1,1) = {"
+wg
+EJ
+kx
+Mt
+bw
+zV
+Un
+QB
+pI
+xk
+Od
+Ui
+pO
+sZ
+uA
+tT
+SG
+SX
+KG
+SN
+Hz
+vd
+mr
+Dt
+fw
+Wz
+Hz
+Lb
+wt
+RV
+mQ
+nm
+nm
+nm
+nm
+nm
+Ra
+KI
+jR
+tE
+Gd
+Ax
+zX
+Oi
+ZY
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(47,1,1) = {"
+wg
+wg
+wg
+wg
+gn
+UQ
+UQ
+UQ
+bw
+bw
+bw
+bw
+bw
+qa
+qH
+jj
+aC
+Cf
+Cf
+Vw
+Hz
+jJ
+lY
+jW
+qo
+JK
+Hz
+zc
+xQ
+wt
+sr
+sr
+sr
+sr
+sr
+sr
+sr
+jR
+xQ
+Ts
+Ax
+Ax
+NB
+NB
+NB
+NB
+kx
+EJ
+wg
+wg
+wg
+wg
+wg
+"}
+(48,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+gv
+bw
+bw
+Hr
+Bt
+Hh
+Bj
+wV
+Hz
+Hz
+Hz
+Hz
+Hz
+Hz
+Hz
+aW
+hM
+hM
+hM
+hM
+hM
+hM
+hM
+hM
+hM
+hM
+hM
+Mt
+Ax
+Ay
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(49,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+gn
+bw
+bw
+bw
+bw
+bw
+Hz
+kx
+kx
+kx
+wg
+wg
+wg
+kx
+wg
+kx
+wg
+EJ
+ss
+aJ
+zv
+EJ
+wg
+kx
+wg
+kx
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(50,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+EJ
+wg
+kx
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+kx
+wg
+EJ
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(51,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+kx
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+kx
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+"}
+(52,1,1) = {"
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+EJ
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+EJ
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
 "}

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon2.dmm
@@ -4697,8 +4697,8 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/item/circuitboard/machine/circuit_imprinter/offstation,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard/machine/circuit_imprinter,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "An" = (
@@ -7781,8 +7781,8 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "QY" = (
-/obj/item/circuitboard/machine/protolathe/offstation,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard/machine/protolathe,
 /turf/open/floor/cult,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "Rc" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon3.dmm
@@ -352,10 +352,10 @@
 "cc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/protolathe/offstation,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
+/obj/item/circuitboard/machine/protolathe,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "cd" = (
@@ -7501,10 +7501,10 @@
 "RI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/circuit_imprinter/offstation,
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
+/obj/item/circuitboard/machine/circuit_imprinter,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "RJ" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon4.dmm
@@ -309,11 +309,11 @@
 /area/ruin/space/has_grav/port_tarkon/developement)
 "cc" = (
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/protolathe/offstation,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard/machine/protolathe,
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "cd" = (
@@ -6609,11 +6609,11 @@
 /area/ruin/space/has_grav/port_tarkon/developement)
 "RI" = (
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/circuit_imprinter/offstation,
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard/machine/circuit_imprinter,
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "RJ" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon5.dmm
@@ -346,11 +346,11 @@
 /area/ruin/space/has_grav/port_tarkon/secoff)
 "cc" = (
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/protolathe/offstation,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard/machine/protolathe,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "cd" = (
@@ -7268,11 +7268,11 @@
 /area/ruin/space/has_grav/port_tarkon/developement)
 "RI" = (
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/circuit_imprinter/offstation,
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/circuitboard/machine/circuit_imprinter,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "RJ" = (

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -239,9 +239,6 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/rnd/production/protolathe/department/engineering
 
-/obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
-	build_path = /obj/machinery/rnd/production/protolathe/department/engineering/no_tax
-
 /obj/item/circuitboard/machine/rtg
 	name = "RTG"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/game/objects/items/storage/boxes/science_boxes.dm
+++ b/code/game/objects/items/storage/boxes/science_boxes.dm
@@ -103,10 +103,14 @@
 	illustration = "scicircuit"
 
 /obj/item/storage/box/rndboards/PopulateContents()
-	new /obj/item/circuitboard/machine/protolathe/offstation(src)
+	new /obj/item/circuitboard/machine/protolathe(src)
 	new /obj/item/circuitboard/machine/destructive_analyzer(src)
-	new /obj/item/circuitboard/machine/circuit_imprinter/offstation(src)
+	new /obj/item/circuitboard/machine/circuit_imprinter(src)
 	new /obj/item/circuitboard/computer/rdconsole(src)
+
+/obj/item/storage/box/rndboards/mundane
+	name = "research kit"
+	desc = "A box containing a D.I.Y. research equipment set. Some assembly required."
 
 /obj/item/storage/box/stabilized //every single stabilized extract from xenobiology
 	name = "box of stabilized extracts"

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -29,7 +29,7 @@
 	var/stripe_color = null
 
 	/// Does this charge the user's ID on fabrication?
-	var/charges_tax = TRUE
+	var/charges_tax = FALSE
 
 /obj/machinery/rnd/production/Initialize(mapload)
 	. = ..()

--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -21,4 +21,3 @@
 	desc = "Manufactures circuit boards for the construction of machines. Its ancient construction may limit its ability to print all known technology."
 	allowed_buildtypes = AWAY_IMPRINTER
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/offstation
-	charges_tax = FALSE

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -12,10 +12,6 @@
 	stripe_color = "#EFB341"
 	payment_department = ACCOUNT_ENG
 
-/obj/machinery/rnd/production/protolathe/department/engineering/no_tax
-	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
-	charges_tax = FALSE
-
 /obj/machinery/rnd/production/protolathe/department/service
 	name = "department protolathe (Service)"
 	allowed_department_flags = DEPARTMENT_BITFLAG_SERVICE

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -23,4 +23,3 @@
 	desc = "Converts raw materials into useful objects. Its ancient construction may limit its ability to print all known technology."
 	circuit = /obj/item/circuitboard/machine/protolathe/offstation
 	allowed_buildtypes = AWAY_LATHE
-	charges_tax = FALSE

--- a/modular_skyrat/master_files/code/modules/research/machinery/departmental_circuit_imprinter.dm
+++ b/modular_skyrat/master_files/code/modules/research/machinery/departmental_circuit_imprinter.dm
@@ -1,5 +1,0 @@
-/obj/item/circuitboard/machine/circuit_imprinter/department/no_tax
-	build_path = /obj/machinery/rnd/production/circuit_imprinter/department/no_tax
-
-/obj/machinery/rnd/production/circuit_imprinter/department/no_tax
-	charges_tax = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5174,7 +5174,6 @@
 #include "modular_skyrat\master_files\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\designs\medical_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\designs\misc_designs.dm"
-#include "modular_skyrat\master_files\code\modules\research\machinery\departmental_circuit_imprinter.dm"
 #include "modular_skyrat\master_files\code\modules\research\techweb\all_nodes.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\surgery.dm"


### PR DESCRIPTION
https://www.youtube.com/watch?v=aHl0h6nHBNM
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Lathes no longer tax silicons or people not of their assigned department - by default.
balance: Ghostroles have omnilathes again. Surely this can't go wrong.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
