### PR TITLE
[LORE] WB-32 Tools + Stock Parts, Minus Sprites

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -247,7 +247,7 @@
 		return TRUE
 
 	// Same for anyone with an abductor multitool.
-	if(user.is_holding_item_of_type(/obj/item/multitool/abductor))
+	if(user.is_holding_item_of_type(/obj/item/multitool/abductor) || user.is_holding_item_of_type(/obj/item/multitool/abductor/wb32)) // This needs to be a var on multitools to avoid this awful behavior.
 		return TRUE
 
 	// Station blueprints do that too, but only if the wires are not randomized.

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -136,6 +136,12 @@
 	custom_materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/plasma = 5000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	toolspeed = 0.1
 
+/obj/item/multitool/abductor/wb32
+	name = "WB-32 Skeleton Key"
+	desc = "The reverse engineering community is a prevalent culture - discussing how technology works under the hood has historically lead to incredible contraptions, and has led \
+	to the prevalence of remote signalling devices, for work, pleasure, and otherwise, in the modern day and age. Skeleton Keys like this one provide easy access to any and all \
+	wire-related information directly to a user's neurons, or lack thereof, for specialty situations WB-32 chooses."
+
 /obj/item/multitool/cyborg//SKYRAT EDIT - ICON OVERRIDEN BY AESTHETICS - SEE MODULE
 	name = "electronic multitool"
 	desc = "Optimised version of a regular multitool. Streamlines processes handled by its internal microchip."

--- a/code/game/objects/items/storage/boxes/science_boxes.dm
+++ b/code/game/objects/items/storage/boxes/science_boxes.dm
@@ -97,6 +97,20 @@
 		)
 	generate_items_inside(items_inside,src)
 
+/obj/item/storage/box/stockparts/wb32
+	name = "box of WB-32's stock parts"
+	desc = "Contains a variety of cutting-edge stock parts."
+
+/obj/item/storage/box/stockparts/wb32/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/stock_parts/capacitor/wb32 = 3,
+		/obj/item/stock_parts/scanning_module/wb32 = 3,
+		/obj/item/stock_parts/manipulator/wb32 = 3,
+		/obj/item/stock_parts/micro_laser/wb32 = 3,
+		/obj/item/stock_parts/matter_bin/wb32 = 3,
+		)
+	generate_items_inside(items_inside,src)
+
 /obj/item/storage/box/rndboards
 	name = "\proper the liberator's legacy"
 	desc = "A box containing a gift for worthy golems."

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -99,6 +99,14 @@
 	toolspeed = 0.7
 	force_opens = TRUE
 
+/obj/item/crowbar/power/wb32
+	name = "WB-32 Seperation Jaws"
+	desc = "One of the most hazardous environments for paramedics and salvage workers alike is deep space. While traditional \
+	prying and cutting equipment proved effective for smaller cruisers and freighters, the growing prevalance of collosus-class \
+	vessels opened a need in the market for more effective tools in both markets, and, owing to supposed mechanical similarities \
+	researchers have been unable to decipher, WB-32 alleviated both needs with one device."
+	toolspeed = 0.1 // And the lord said, "My son, walk in the light, for it is you who shall lead the tide"
+
 /obj/item/crowbar/power/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/transforming, \

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -89,6 +89,8 @@
 	attack_verb_simple = list("drill", "screw", "jab", "whack")
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
+	/// Sound we use when replacing the drillbit.
+	var/bitsound = 'sound/items/change_drill.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
 	random_color = FALSE
@@ -96,6 +98,16 @@
 	greyscale_config_belt = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+
+/obj/item/screwdriver/power/wb32
+	name = "WB-32 Hardlight-Tipped Drill"
+	desc = "Even the formerly simple hand drill has, inevitably, been reconsidered by WB-32 - An impossibly tactile grip fits with a \
+	drillbit that will always, unsettlingly, manage to fit it's target perfectly."
+	toolspeed = 0.1
+	hitsound = 'sound/weapons/pulse.ogg'
+	usesound = 'sound/weapons/blade1.ogg'
+	bitsound = 'saberon'
+
 
 /obj/item/screwdriver/power/Initialize(mapload)
 	. = ..()
@@ -117,7 +129,7 @@
 
 	tool_behaviour = (active ? TOOL_WRENCH : TOOL_SCREWDRIVER)
 	balloon_alert(user, "attached [active ? "bolt bit" : "screw bit"]")
-	playsound(user ? user : src, 'sound/items/change_drill.ogg', 50, TRUE)
+	playsound(user ? user : src, bitsound, 50, TRUE)
 	return COMPONENT_NO_DEFAULT_MESSAGE
 
 /obj/item/screwdriver/power/examine()

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -106,7 +106,7 @@
 	toolspeed = 0.1
 	hitsound = 'sound/weapons/pulse.ogg'
 	usesound = 'sound/weapons/blade1.ogg'
-	bitsound = 'saberon'
+	bitsound = 'sound/weapons/saberon.ogg'
 
 
 /obj/item/screwdriver/power/Initialize(mapload)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -342,7 +342,7 @@
 
 /obj/item/weldingtool/largetank/flamethrower_screwdriver()
 	return
-	
+
 /obj/item/weldingtool/largetank/empty
 	starting_fuel = FALSE
 
@@ -384,11 +384,19 @@
 	light_system = NO_LIGHT_SUPPORT
 	light_range = 0
 	change_icons = FALSE
+	var/refill_amount = 1
 
 /obj/item/weldingtool/abductor/process()
 	if(get_fuel() <= max_fuel)
-		reagents.add_reagent(/datum/reagent/fuel, 1)
+		reagents.add_reagent(/datum/reagent/fuel, refill_amount)
 	..()
+
+/obj/item/weldingtool/abductor/wb32 // This wasn't going to just be a retheme but whatever sick fuck made it so that light_system and light_range are responsible for welding tools blinding you is :(
+	name = "WB-32 Nano-Gen Welding Tool"
+	desc = "In the vastness of space, welding fuel is a logistical nightmare. Carrying large quantities will, inevitably, be a disaster - \
+	and most of the supply may very easily end up having to be used to fend off the damage done simply by carrying it, with anything from \
+	stray meteors to debris commonly leading to agonizingly long chains of accidents. Enter, WB-32's Nano-Gen welder. Passively generating \
+	welding fuel on the fly, welders like these have historically saved many a freighter simply by existing. Allegedly."
 
 /obj/item/weldingtool/hugetank
 	name = "upgraded industrial welding tool"

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -384,11 +384,10 @@
 	light_system = NO_LIGHT_SUPPORT
 	light_range = 0
 	change_icons = FALSE
-	var/refill_amount = 1
 
 /obj/item/weldingtool/abductor/process()
 	if(get_fuel() <= max_fuel)
-		reagents.add_reagent(/datum/reagent/fuel, refill_amount)
+		reagents.add_reagent(/datum/reagent/fuel, 1)
 	..()
 
 /obj/item/weldingtool/abductor/wb32 // This wasn't going to just be a retheme but whatever sick fuck made it so that light_system and light_range are responsible for welding tools blinding you is :(

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -398,6 +398,9 @@
 	custom_materials = list(/datum/material/glass=600)
 	chargerate = 4000
 
+/obj/item/stock_parts/cell/bluespace/empty
+	empty = TRUE
+
 /obj/item/stock_parts/cell/bluespacereactor
 	empty = TRUE
 	name = "bluespace reactor power cell"
@@ -408,8 +411,13 @@
 	chargerate = 400
 	self_recharge = 1
 
-/obj/item/stock_parts/cell/bluespace/empty
-	empty = TRUE
+/obj/item/stock_parts/cell/bluespacereactor/wb32
+	name = "WB-32 Quantum MicroReactor"
+	desc = "Rumormills beleive microreactors like these were originally made due to WB-32 misunderstanding the concept of gift-giving, \
+	to, quote, \"Treat itself\". Those of a less cynical mindset simply beleive they were made for conveinence and planetary restriction, \
+	especially for harvesting rigs on the \"surface\" of gas giants."
+	maxcharge = 100000
+	chargerate = 5000 // Probably sustains every single possible model of station at once, if it was ever given the chance.
 
 /obj/item/stock_parts/cell/infinite
 	name = "infinite-capacity power cell"

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -411,6 +411,48 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	energy_rating = 10
 	custom_materials = list(/datum/material/iron=80)
 
+//Rating 5
+
+/obj/item/stock_parts/capacitor/wb32
+	name = "WB-32 capacitor"
+	desc = "Impossibly high-load capacitors, meant to withstand even the load of several silicon units simultaneously."
+	icon_state = "quadratic_capacitor"
+	rating = 5
+	energy_rating = 15
+	custom_materials = list(/datum/material/iron=10, /datum/material/glass=10) // Imagine recycling archotechnology. Bozo
+
+/obj/item/stock_parts/scanning_module/wb32
+	name = "WB-32 scanning module"
+	desc = "An ultra-thin scanning module, designed for near instant identification."
+	icon_state = "triphasic_scan_module"
+	rating = 5
+	energy_rating = 15
+	custom_materials = list(/datum/material/iron=10, /datum/material/glass=10)
+
+/obj/item/stock_parts/manipulator/wb32
+	name = "WB-32 manipulator"
+	desc = "A manipulator the size of your pinky that can effortlessly manipulate anything from entire mechas to the atoms forming them."
+	icon_state = "femto_mani"
+	rating = 5
+	energy_rating = 15
+	custom_materials = list(/datum/material/iron=10)
+
+/obj/item/stock_parts/micro_laser/wb32
+	name = "WB-32 micro-laser"
+	icon_state = "quadultra_micro_laser"
+	desc = "A tiny tube and laser assembly, precise and quick enough to have already finished burning words into the floor while you examined it."
+	rating = 5 // Borgs weeping
+	energy_rating = 15
+	custom_materials = list(/datum/material/iron=10, /datum/material/glass=10)
+
+/obj/item/stock_parts/matter_bin/wb32
+	name = "WB-32 matter bin"
+	desc = "It's theorized just one of these could hold the combined molecules of an entire Terran county."
+	icon_state = "bluespace_matter_bin"
+	rating = 5
+	energy_rating = 15
+	custom_materials = list(/datum/material/iron=80)
+
 // Subspace stock parts
 
 /obj/item/stock_parts/subspace/ansible

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -153,9 +153,6 @@ If you create T6+ please take a pass at mech_fabricator.dm. The parts being good
 	if(removed_component.reagents)
 		UnregisterSignal(removed_component.reagents, COMSIG_REAGENTS_PRE_ADD_REAGENT)
 
-
-/obj/item/storage/part_replacer/bluespace/tier1
-
 /obj/item/storage/part_replacer/bluespace/tier1/PopulateContents()
 	for(var/i in 1 to 10)
 		new /obj/item/stock_parts/capacitor(src)
@@ -164,8 +161,6 @@ If you create T6+ please take a pass at mech_fabricator.dm. The parts being good
 		new /obj/item/stock_parts/micro_laser(src)
 		new /obj/item/stock_parts/matter_bin(src)
 		new /obj/item/stock_parts/cell/high(src)
-
-/obj/item/storage/part_replacer/bluespace/tier2
 
 /obj/item/storage/part_replacer/bluespace/tier2/PopulateContents()
 	for(var/i in 1 to 10)
@@ -176,8 +171,6 @@ If you create T6+ please take a pass at mech_fabricator.dm. The parts being good
 		new /obj/item/stock_parts/matter_bin/adv(src)
 		new /obj/item/stock_parts/cell/super(src)
 
-/obj/item/storage/part_replacer/bluespace/tier3
-
 /obj/item/storage/part_replacer/bluespace/tier3/PopulateContents()
 	for(var/i in 1 to 10)
 		new /obj/item/stock_parts/capacitor/super(src)
@@ -187,8 +180,6 @@ If you create T6+ please take a pass at mech_fabricator.dm. The parts being good
 		new /obj/item/stock_parts/matter_bin/super(src)
 		new /obj/item/stock_parts/cell/hyper(src)
 
-/obj/item/storage/part_replacer/bluespace/tier4
-
 /obj/item/storage/part_replacer/bluespace/tier4/PopulateContents()
 	for(var/i in 1 to 10)
 		new /obj/item/stock_parts/capacitor/quadratic(src)
@@ -197,6 +188,15 @@ If you create T6+ please take a pass at mech_fabricator.dm. The parts being good
 		new /obj/item/stock_parts/micro_laser/quadultra(src)
 		new /obj/item/stock_parts/matter_bin/bluespace(src)
 		new /obj/item/stock_parts/cell/bluespace(src)
+
+/obj/item/storage/part_replacer/bluespace/tier5/PopulateContents()
+	for(var/i in 1 to 10)
+		new /obj/item/stock_parts/capacitor/wb32(src)
+		new /obj/item/stock_parts/scanning_module/wb32(src)
+		new /obj/item/stock_parts/manipulator/wb32(src)
+		new /obj/item/stock_parts/micro_laser/wb32(src)
+		new /obj/item/stock_parts/matter_bin/wb32(src)
+		new /obj/item/stock_parts/cell/bluespacereactor/wb32(src)
 
 /obj/item/storage/part_replacer/cargo //used in a cargo crate
 

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -1,6 +1,6 @@
 /*Power cells are in code\modules\power\cell.dm
 
-If you create T5+ please take a pass at mech_fabricator.dm. The parts being good enough allows it to go into minus values and create materials out of thin air when printing stuff.*/
+If you create T6+ please take a pass at mech_fabricator.dm. The parts being good enough allows it to go into minus values and create materials out of thin air when printing stuff.*/
 /obj/item/storage/part_replacer//SKYRAT EDIT - ICON OVERRIDEN BY AESTHETICS - SEE MODULE
 	name = "rapid part exchange device"
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."

--- a/code/modules/research/stock_parts/stock_part_datum.dm
+++ b/code/modules/research/stock_parts/stock_part_datum.dm
@@ -64,6 +64,8 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 			return 5
 		if (4)
 			return 10
+		if (5)
+			return 15
 		else
 			CRASH("Invalid level given to energy_rating: [tier]")
 
@@ -83,3 +85,7 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 /datum/stock_part/scanning_module/tier4
 	tier = 4
 	physical_object_type = /obj/item/stock_parts/scanning_module/triphasic
+
+/datum/stock_part/scanning_module/tier5
+	tier = 5
+	physical_object_type = /obj/item/stock_parts/scanning_module/wb32

--- a/modular_skyrat/modules/icspawning/code/standard.dm
+++ b/modular_skyrat/modules/icspawning/code/standard.dm
@@ -20,6 +20,15 @@
 	name = "\improper Bluespace Tech's belt"
 	w_class = WEIGHT_CLASS_TINY
 
+/obj/item/storage/belt/utility/chief/full/debug/PopulateContents()
+	SSwardrobe.provide_type(/obj/item/screwdriver/power/wb32, src)
+	SSwardrobe.provide_type(/obj/item/crowbar/power/wb32, src)
+	SSwardrobe.provide_type(/obj/item/weldingtool/abductor/wb32, src)
+	SSwardrobe.provide_type(/obj/item/multitool/abductor/wb32, src)
+	SSwardrobe.provide_type(/obj/item/stack/cable_coil, src)
+	SSwardrobe.provide_type(/obj/item/extinguisher/mini, src)
+	SSwardrobe.provide_type(/obj/item/analyzer/ranged, src)
+
 /datum/outfit/debug/bst //Debug objs
 	name = "Bluespace Tech"
 	uniform = /obj/item/clothing/under/syndicate/combat

--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -13,7 +13,7 @@
 	var/max_batteries = 4
 	var/charge_rate = 250
 	var/charge_rate_base = 250 // Amount of charge we gain from a level one capacitor
-	var/charge_rate_max = 4000 // The highest we allow the charge rate to go
+	var/charge_rate_max = 6000 // The highest we allow the charge rate to go. Why clamp this?? we may never know
 
 /obj/machinery/cell_charger_multi/update_overlays()
 	. = ..()


### PR DESCRIPTION
These need sprites too (I beleive someone else was already asked?) But codewise, they're complete. I've tested to make sure material count doesn't underflow personally, and everything SEEMS to be above board.

Also gives BSTS WB-32 tools, which are either rethemes or upgrades to abductor tools.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Lore-Based, nigh unobtainable Stock Parts and tools have been added. Will YOU see them?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
