### PR TITLE
[FUCK] Jaws prying is now affected by toolspeed

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1129,6 +1129,8 @@
 				var/time_to_open = 50
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
 				prying_so_hard = TRUE
+				if(I)
+					time_to_open = 71.43 * I.toolspeed // Rounds down so that basic jaws of life (toolspeed 0.7) are IDENTICAL speed to xenomorphs prying
 				if(do_after(user, time_to_open, src))
 					if(check_electrified && shock(user,100))
 						prying_so_hard = FALSE


### PR DESCRIPTION
Hey did you know that the admin jaws were IDENTICAL speed to normal jaws because of this goofy bit hijinx
this addresses that, making the admin-only jaws actually fast as fuck

also the syndicate ones I guess
:cl:
balance: The syndicate jaws of life now, genuinely, pries doors faster than the normal version.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
