### PR TITLE
1984s Soylent Green

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -389,7 +389,6 @@
 	minimal_access = list(
 		ACCESS_KITCHEN,
 		ACCESS_MINERAL_STOREROOM,
-		ACCESS_MORGUE,
 		ACCESS_SERVICE,
 		)
 	extra_access = list(


### PR DESCRIPTION

:cl:
del: The chef no longer has morgue access. You know why.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
