### PR TITLE
[REQ] Station traits are now a config flag

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -649,3 +649,5 @@
 	default = 50
 
 /datum/config_entry/string/morgue_cadaver_override_species
+
+/datum/config_entry/flag/no_station_traits // Do we disable station traits? Uncommenting will disable station traits

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -30,6 +30,8 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	#ifdef LOWMEMORYMODE // NO MORE FUCKING STUPID STATION TRAITS ON STARTUP WHEN IM TESTING SHIT FUCK YOU
 	return
 	#endif
+	if (CONFIG_GET(flag/no_station_traits))
+		return // I'm sorry, my Intern
 	// SKYRAT EDIT END
 
 	if (fexists(FUTURE_STATION_TRAITS_FILE))

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -553,3 +553,6 @@ MAXFINE 2000
 ## Comment if you wish to enable title music playing at the lobby screen. This flag is disabled by default to facilitate better code testing on local machines.
 ## Do keep in mind that this flag will not affect individual player's preferences: if they opt-out on your server, it will never play for them.
 DISALLOW_TITLE_MUSIC
+
+## Uncomment if you wish to disable station traits. Useful for testing or bozos.
+NO_STATION_TRAITS


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
config: Station Traits can now be disabled via the use of a config flag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
