### PR TITLE
[REQ] [Revert Later] Disables Sideplane

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -19,7 +19,9 @@
 	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "/tg/ Station 13"
 	fps = 20
+	/* // TL;DR, Skyrat broke /tg/'s sidemap changes and we've been dealing with the fallout. Until we get a proper fix, this is an effective bandaid.
 	map_format = SIDE_MAP
+	*/
 #ifdef FIND_REF_NO_CHECK_TICK
 	loop_checks = FALSE
 #endif


### PR DESCRIPTION
I don't beleive skyrat is liable to produce a proper fix anytime soon. This is a psuedo-permanent solution to the table/item/player layering issue.
