### PR TITLE
[REQ] Re-Implements Sleepers

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1076,13 +1076,6 @@
 /area/station/cargo/office)
 "amR" = (
 /obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/hud/health,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -1090,6 +1083,17 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "amS" = (
@@ -13096,18 +13100,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"dck" = (
-/obj/machinery/defibrillator_mount/directional/south,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/beakers,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron,
-/area/station/medical/treatment_center)
 "dcG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/landmark/start/depsec/science,
@@ -14295,10 +14287,10 @@
 "dsM" = (
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/suit/apron/surgical,
+/obj/structure/window/spawner/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "dsN" = (
@@ -15225,7 +15217,6 @@
 	},
 /obj/item/storage/pill_bottle/mannitol,
 /obj/item/reagent_containers/dropper,
-/obj/structure/window/reinforced/spawner,
 /obj/machinery/camera/directional/west{
 	c_tag = "Medbay - Cryogenics";
 	name = "medical camera";
@@ -15237,6 +15228,7 @@
 	},
 /obj/effect/turf_decal/siding/blue,
 /obj/structure/table/glass,
+/obj/structure/window,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "dEv" = (
@@ -28505,7 +28497,13 @@
 /obj/item/storage/belt/medical{
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/storage/box/rxglasses{
+	pixel_x = -6
+	},
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "gQK" = (
@@ -43859,12 +43857,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "kDA" = (
-/obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 8
 	},
 /obj/machinery/shower/directional/west,
+/obj/structure/window/spawner/north,
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
 "kDE" = (
@@ -44653,7 +44651,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "kNT" = (
-/obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -44661,6 +44658,7 @@
 /obj/vehicle/ridden/wheelchair{
 	dir = 8
 	},
+/obj/structure/window/spawner/north,
 /turf/open/floor/iron/textured,
 /area/station/medical/medbay)
 "kNY" = (
@@ -53207,7 +53205,6 @@
 	pixel_y = 36
 	},
 /obj/machinery/light_switch/directional/north,
-/obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -53215,6 +53212,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical1,
+/obj/structure/window/spawner/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "mSZ" = (
@@ -56553,11 +56551,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "nLB" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/storage/box/rxglasses,
 /obj/machinery/light/directional/south,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/diagonal,
 /area/station/medical/treatment_center)
 "nLF" = (
 /obj/structure/disposalpipe/segment,
@@ -61381,13 +61378,13 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office/private_investigators_office)
 "paA" = (
-/obj/structure/bed/pod{
-	desc = "An old medical bed, just waiting for replacement with something up to date.";
-	name = "medical bed"
+/obj/structure/window/spawner/east,
+/obj/machinery/sleeper{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/diagonal,
 /area/station/medical/treatment_center)
 "paQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -91922,13 +91919,13 @@
 /area/station/command/heads_quarters/hop)
 "wqQ" = (
 /obj/item/radio/intercom/directional/east,
-/obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/blue,
 /obj/machinery/shower/directional/west,
+/obj/structure/window,
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
 "wqT" = (
@@ -141078,7 +141075,7 @@ okk
 sKV
 efb
 paA
-dck
+paA
 oDE
 oDE
 oDE

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10521,12 +10521,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ddu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ddz" = (
@@ -10626,11 +10624,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dgl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "dgm" = (
 /obj/machinery/light/small/directional/west,
@@ -15591,11 +15590,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "eHZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "eIa" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -16612,6 +16612,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "eWV" = (
@@ -22060,10 +22061,11 @@
 "gHq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/computer/crew{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "gHv" = (
 /turf/open/floor/plating,
@@ -24609,11 +24611,8 @@
 "hxs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/computer/med_data{
-	dir = 1
-	},
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "hxz" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -27558,11 +27557,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "iuD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -32189,6 +32188,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"jQa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "jQd" = (
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
@@ -36390,6 +36395,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "lca" = (
@@ -40698,6 +40704,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "mzM" = (
@@ -43151,6 +43160,13 @@
 	},
 /turf/open/openspace,
 /area/station/science/ordnance/office)
+"nmB" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "nmD" = (
 /obj/structure/railing{
 	dir = 8
@@ -43921,9 +43937,10 @@
 "nzs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nzB" = (
 /obj/effect/turf_decal/trimline/blue/warning{
@@ -52439,6 +52456,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
+"qeg" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "qeh" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -52996,6 +53020,9 @@
 "qoi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -53679,11 +53706,11 @@
 "qAf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/computer/med_data{
+	dir = 8
 	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "qAz" = (
 /obj/structure/disposalpipe/trunk/multiz{
@@ -57240,9 +57267,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "rEG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -62236,6 +62265,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "tkk" = (
@@ -66817,9 +66849,9 @@
 "uEr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/medical_kiosk,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/large,
+/obj/structure/window/fulltile,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "uEA" = (
 /obj/structure/closet/crate,
@@ -71490,9 +71522,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/mine/laborcamp)
 "wbw" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -73377,7 +73406,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "wDe" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/medical_doctor,
@@ -78508,8 +78536,8 @@
 "ygF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -246479,9 +246507,9 @@ fPb
 bEL
 efK
 evp
-juw
+nmB
 tkf
-ikz
+fUL
 lbC
 tHr
 pBA
@@ -246735,14 +246763,14 @@ xPT
 cxA
 lka
 vkD
-cey
-lux
+nji
+rpM
 eHZ
-lux
-fUL
-evp
-evp
-evp
+jQa
+qeg
+rEG
+rEG
+iuD
 ucp
 eWT
 hpp
@@ -246996,7 +247024,7 @@ wDe
 hxs
 uEr
 nzs
-iuD
+hxs
 qAf
 gHq
 ygF
@@ -247252,8 +247280,8 @@ lzM
 wbw
 ddu
 dgl
-evp
-rEG
+jQa
+rpM
 iEA
 olI
 oyB
@@ -247509,7 +247537,7 @@ vqX
 lgk
 qoi
 mzL
-nji
+juw
 ikz
 evp
 hRH

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2499,8 +2499,6 @@
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/obj/structure/table,
-/obj/item/book/manual/wiki/medicine,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -2508,6 +2506,10 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/machinery/sleeper{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/exam_room)
 "aHD" = (
@@ -70851,13 +70853,9 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/chair{
-	desc = "A gray chair. Nothing more relaxing while waiting for therapy than watching the dying.";
-	dir = 8;
-	name = "therapy waiting chair"
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/exam_room)
 "ugr" = (
@@ -71101,7 +71099,9 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/bot,
-/obj/machinery/vending/drugs,
+/obj/machinery/sleeper{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/exam_room)
 "ukM" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2259,14 +2259,12 @@
 /turf/open/space,
 /area/space/nearstation)
 "aPe" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/defibrillator_mount/directional/south,
 /obj/machinery/light/directional/south,
-/obj/structure/bed/pod{
-	desc = "An old medical bed, just waiting for replacement with something up to date.";
-	name = "medical bed"
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/diagonal,
 /area/station/medical/treatment_center)
 "aPj" = (
 /obj/effect/landmark/event_spawn,
@@ -6956,6 +6954,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"cBm" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/station/medical/treatment_center)
 "cBw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
@@ -9715,6 +9722,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/library)
+"dFm" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/station/medical/treatment_center)
 "dFo" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -34588,6 +34604,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"msl" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/station/medical/treatment_center)
 "msu" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -90334,7 +90357,7 @@ hMq
 sxf
 iMv
 nKE
-xtu
+msl
 rvb
 uod
 wWs
@@ -90847,8 +90870,8 @@ xQC
 kLZ
 iUJ
 bJk
-ppG
-ppG
+dFm
+cBm
 vun
 mZD
 cho

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1468,6 +1468,17 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos/pumproom)
+"auL" = (
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 5
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/station/medical/medbay/central)
 "auP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -78422,6 +78433,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"vMm" = (
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 6
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/station/medical/medbay/central)
 "vMr" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -114618,8 +114640,8 @@ kCj
 qft
 fve
 eFN
-eFN
-eFN
+auL
+vMm
 eFN
 rOB
 tSw

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1676,12 +1676,7 @@
 /area/station/maintenance/tram/left)
 "aKO" = (
 /obj/effect/turf_decal/box,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/lavaland/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/drain,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/white,
@@ -23580,12 +23575,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "iCA" = (
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/lavaland/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/drain,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31497,9 +31487,9 @@
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "lrQ" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/obj/structure/window/fulltile,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "lrU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32134,6 +32124,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
+"lBz" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "lBB" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -39742,6 +39737,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"opn" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/medical/treatment_center)
 "opr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41719,6 +41723,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"pcI" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/medical/treatment_center)
 "pcK" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
@@ -45912,12 +45925,7 @@
 /area/station/cargo/warehouse)
 "qym" = (
 /obj/effect/turf_decal/box,
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/lavaland/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/drain,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/shower/directional/west,
 /turf/open/floor/iron/white,
@@ -67004,12 +67012,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ydw" = (
-/obj/structure/fluff{
-	desc = "What, you think the water just magically soaks into the metallic flooring?";
-	icon = 'icons/obj/lavaland/survival_pod.dmi';
-	icon_state = "fan_tiny";
-	name = "shower drain"
-	},
+/obj/structure/drain,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -164807,7 +164810,7 @@ qym
 wbT
 dvQ
 uZQ
-xOn
+pcI
 dkW
 dkW
 pXJ
@@ -165065,7 +165068,7 @@ ecW
 dXo
 lTc
 lrQ
-xOn
+lBz
 dkW
 dHv
 xSZ
@@ -165321,7 +165324,7 @@ aKO
 krE
 bvK
 eGn
-xOn
+opn
 xOn
 dkW
 sIq

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -19,7 +19,7 @@
 	///Whether the machine can be operated by the person inside of it.
 	var/controls_inside = FALSE
 	///Whether this sleeper can be deconstructed and drop the board, if its on mapload.
-	var/deconstructable = FALSE
+	var/deconstructable = TRUE
 	///Message sent when a user enters the machine.
 	var/enter_message = span_boldnotice("You feel cool air surround you. You go numb as your senses turn inward.")
 
@@ -300,17 +300,17 @@
 
 /**
  * Syndicate version
- * Can be controlled from the inside and can be deconstructed.
+ * Can be controlled from the inside.
  */
 /obj/machinery/sleeper/syndie
 	icon_state = "sleeper_s"
 	base_icon_state = "sleeper_s"
+	circuit = /obj/item/circuitboard/machine/sleeper/syndicate
 	controls_inside = TRUE
-	deconstructable = TRUE
 
 ///Fully upgraded variant, the circuit using tier 4 parts.
 /obj/machinery/sleeper/syndie/fullupgrade
-	circuit = /obj/item/circuitboard/machine/sleeper/fullupgrade
+	circuit = /obj/item/circuitboard/machine/sleeper/syndicate/fullupgrade
 
 /obj/machinery/sleeper/self_control
 	controls_inside = TRUE
@@ -318,6 +318,7 @@
 /obj/machinery/sleeper/old
 	icon_state = "oldpod"
 	base_icon_state = "oldpod"
+	deconstructable = FALSE
 
 /obj/machinery/sleeper/party
 	name = "party pod"
@@ -326,7 +327,6 @@
 	base_icon_state = "partypod"
 	circuit = /obj/item/circuitboard/machine/sleeper/party
 	controls_inside = TRUE
-	deconstructable = TRUE
 	enter_message = span_boldnotice("You're surrounded by some funky music inside the chamber. You zone out as you feel waves of krunk vibe within you.")
 
 	//Exclusively uses non-lethal, "fun" chems. At an obvious downside.
@@ -346,6 +346,10 @@
 		list(
 			/datum/reagent/drug/space_drugs,
 			/datum/reagent/baldium,
+		),
+		list(
+			/datum/reagent/drug/aphrodisiac/crocin,
+			/datum/reagent/drug/aphrodisiac/camphor,
 		),
 	)
 	///Chemicals that need to have a touch or vapor reaction to be applied, not the standard chamber reaction.

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -808,7 +808,11 @@
 		/obj/item/stack/cable_coil = 1,
 		/obj/item/stack/sheet/glass = 2)
 
-/obj/item/circuitboard/machine/sleeper/fullupgrade
+/obj/item/circuitboard/machine/sleeper/syndicate
+	name = "Syndicate Sleeper"
+	build_path = /obj/machinery/sleeper/syndie
+
+/obj/item/circuitboard/machine/sleeper/syndicate/fullupgrade
 	build_path = /obj/machinery/sleeper/syndie/fullupgrade
 	req_components = list(
 		/obj/item/stock_parts/matter_bin/bluespace = 1,

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -684,6 +684,26 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
+/datum/design/board/sleeper
+	name = "Sleeper Board"
+	desc = "The circuit board for a sleeper."
+	id = "sleeper"
+	build_path = /obj/item/circuitboard/machine/sleeper
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_MEDICAL
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+/datum/design/board/syndiesleeper
+	name = "Syndicate Sleeper Board"
+	desc = "The circuit board for a syndicate sleeper."
+	id = "syndsleeper"
+	build_path = /obj/item/circuitboard/machine/sleeper/syndicate
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_MEDICAL
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
 /datum/design/board/limbgrower
 	name = "Limb Grower Board"
 	desc = "The circuit board for a limb grower."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -438,6 +438,7 @@
 		"piercesyringe",
 		"plasmarefiller",
 		"smoke_machine",
+		"sleeper",
 
 		//SKYRAT EDIT START - RESEARCH DESIGNS
 		"monkey_helmet",
@@ -2261,7 +2262,7 @@
 	id = "syndicate_basic"
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
-	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
+	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons", "adv_biotech")
 	design_ids = list(
 		"advanced_camera",
 		"ai_cam_upgrade",
@@ -2273,6 +2274,7 @@
 		"rapidsyringe",
 		"suppressor",
 		"super_pointy_tape",
+		"syndsleeper",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	hidden = TRUE


### PR DESCRIPTION
:cl:
add: Sleepers have been re-integrated into the techweb - with a special variant if you get illegal tech.
balance: As a consequence, illegal tech now requires advanced biotech. I hope you've been chugging your experiment juice if you want the gamer guns(tm).
balance: Lavaland podperson sleepers no longer are deconstructable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
