### PR TITLE
[REQ] Adds a SAD To medbay roundstart

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -81386,6 +81386,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
+/obj/machinery/self_actualization_device,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "tQP" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5282,6 +5282,13 @@
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"bDM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/self_actualization_device,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/large,
+/area/station/medical/treatment_center)
 "bDO" = (
 /obj/structure/fluff/tram_rail,
 /obj/structure/fluff/tram_rail{
@@ -10524,7 +10531,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ddz" = (
@@ -71523,6 +71532,9 @@
 /area/mine/laborcamp)
 "wbw" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "wbB" = (
@@ -73409,6 +73421,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "wDf" = (
@@ -246763,8 +246776,8 @@ xPT
 cxA
 lka
 vkD
-nji
-rpM
+cey
+pyu
 eHZ
 jQa
 qeg
@@ -247021,7 +247034,7 @@ cxA
 lyl
 nMu
 wDe
-hxs
+bDM
 uEr
 nzs
 hxs

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -70855,7 +70855,8 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/vending/drugs,
+/obj/machinery/self_actualization_device,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/exam_room)
 "ugr" = (
@@ -77228,8 +77229,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
 "vUs" = (
-/obj/structure/bed,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -77240,7 +77239,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/bedsheet/medical,
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "vUt" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -34605,9 +34605,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "msl" = (
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
+	},
+/obj/machinery/self_actualization_device,
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/treatment_center)

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -55823,6 +55823,18 @@
 	dir = 8
 	},
 /area/station/medical/treatment_center)
+"pEm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/self_actualization_device,
+/obj/structure/railing,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/central)
 "pEn" = (
 /turf/closed/wall,
 /area/station/maintenance/aft/greater)
@@ -114639,7 +114651,7 @@ qxO
 kCj
 qft
 fve
-eFN
+pEm
 auL
 vMm
 eFN

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11972,6 +11972,8 @@
 "elW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "emr" = (
@@ -32125,8 +32127,7 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
 "lBz" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/holopad,
+/obj/machinery/self_actualization_device,
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
 "lBB" = (


### PR DESCRIPTION
:cl:
balance: Medical now gets the SAD roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
