### PR TITLE
[REQ] Kills All Fun FOREVER (No More Fun (Lightning Crackle)

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -273,7 +273,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 
 	list(//fakeout items, keep this list at low relative weight
 		/obj/item/clothing/shoes/jackboots = 1,
-		/obj/item/dice/d20 = 1, //To balance out the stealth die of fates in oddities
+		/obj/item/dice/d20 = 1,
 		) = 1,
 ))
 
@@ -347,8 +347,6 @@ GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
 		/obj/item/clothing/head/helmet/abductor = 1,
 		/obj/item/clothing/shoes/jackboots/fast = 1,
 		/obj/item/clothing/suit/armor/reactive/table = 1,
-		/obj/item/dice/d20/fate/stealth/cursed = 1, //Only rolls 1
-		/obj/item/dice/d20/fate/stealth/one_use = 1, //Looks like a d20, keep the d20 in the uncommon pool.
 		/obj/item/shadowcloak = 1,
 		/obj/item/spear/grey_tide = 1,
 		/obj/item/storage/box/donkpockets/donkpocketgondola = 1,

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -158,17 +158,6 @@
 	contains = list()
 	crate_name = "pizza crate"
 
-	///Whether we've provided an infinite pizza box already this shift or not.
-	var/anomalous_box_provided = FALSE
-	/// one percent chance for a pizza box to be the ininfite pizza box
-	var/infinite_pizza_chance = 1
-	///Whether we've provided a bomb pizza box already this shift or not.
-	var/boombox_provided = FALSE
-	/// three percent chance for a pizza box to be the pizza bomb box
-	var/bomb_pizza_chance = 3
-	/// 1 in 3 pizza bombs spawned will be a dud
-	var/bomb_dud_chance = 33
-
 	/// list of pizza that can randomly go inside of a crate, weighted by how disruptive it would be
 	var/list/pizza_types = list(
 		/obj/item/food/pizza/margherita = 10,
@@ -187,40 +176,7 @@
 	. = ..()
 	var/list/rng_pizza_list = pizza_types.Copy()
 	for(var/i in 1 to 5)
-		if(add_anomalous(new_crate))
-			continue
-		if(add_boombox(new_crate))
-			continue
 		add_normal_pizza(new_crate, rng_pizza_list)
-
-/// adds the chance for an infinite pizza box
-/datum/supply_pack/organic/pizza/proc/add_anomalous(obj/structure/closet/crate/new_crate)
-	if(anomalous_box_provided)
-		return FALSE
-	if(!prob(infinite_pizza_chance))
-		return FALSE
-	new /obj/item/pizzabox/infinite(new_crate)
-	anomalous_box_provided = TRUE
-	log_game("An anomalous pizza box was provided in a pizza crate at during cargo delivery.")
-	if(prob(50))
-		addtimer(CALLBACK(src, PROC_REF(anomalous_pizza_report)), rand(30 SECONDS, 180 SECONDS))
-		message_admins("An anomalous pizza box was provided in a pizza crate at during cargo delivery.")
-	else
-		message_admins("An anomalous pizza box was silently created with no command report in a pizza crate delivery.")
-	return TRUE
-
-/// adds a chance of a pizza bomb replacing a pizza
-/datum/supply_pack/organic/pizza/proc/add_boombox(obj/structure/closet/crate/new_crate)
-	if(boombox_provided)
-		return FALSE
-	if(!prob(bomb_pizza_chance))
-		return FALSE
-	var/boombox_type = (prob(bomb_dud_chance)) ? /obj/item/pizzabox/bomb : /obj/item/pizzabox/bomb/armed
-	new boombox_type(new_crate)
-	boombox_provided = TRUE
-	log_game("A pizza box bomb was created by a pizza crate delivery.")
-	message_admins("A pizza box bomb has arrived in a pizza crate delivery.")
-	return TRUE
 
 /// adds a randomized pizza from the pizza list
 /datum/supply_pack/organic/pizza/proc/add_normal_pizza(obj/structure/closet/crate/new_crate, list/rng_pizza_list)
@@ -231,13 +187,6 @@
 	new_pizza_box.boxtag = new_pizza_box.pizza.boxtag
 	new_pizza_box.boxtag_set = TRUE
 	new_pizza_box.update_appearance(UPDATE_ICON | UPDATE_DESC)
-
-/// tells crew that an infinite pizza box exists, half of the time, based on a roll in the anamolous box proc
-/datum/supply_pack/organic/pizza/proc/anomalous_pizza_report()
-	print_command_report("[station_name()], our anomalous materials divison has reported a missing object that is highly likely to have been sent to your station during a routine cargo \
-	delivery. Please search all crates and manifests provided with the delivery and return the object if is located. The object resembles a standard <b>\[DATA EXPUNGED\]</b> and is to be \
-	considered <b>\[REDACTED\]</b> and returned at your leisure. Note that objects the anomaly produces are specifically attuned exactly to the individual opening the anomaly; regardless \
-	of species, the individual will find the object edible and it will taste great according to their personal definitions, which vary significantly based on person and species.")
 
 /datum/supply_pack/organic/potted_plants
 	name = "Potted Plants Crate"

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -17,6 +17,7 @@
 
 /obj/item/gun/energy/pulse/prize
 	pin = /obj/item/firing_pin
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice) // Boowomp
 
 /obj/item/gun/energy/pulse/prize/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
https://www.youtube.com/watch?v=fHH-f-IdbZM

:cl:
del: The die of fate (and it's cursed counterpart) can no longer spawn in maint.
del: Pizza bombs and infinite pizzas can no longer come from Cargo.
balance: The arcade pulse rifle now fires only practice rounds. Boowomp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
