### PR TITLE
[REQ] Purges Required Reagents From Protolathe Designs

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -60,7 +60,6 @@
 	desc = "A device which causes kinetic accelerators to permanently gain damage against creature types killed with it."
 	id = "bountymod"
 	materials = list(/datum/material/iron = 4000, /datum/material/silver = 4000, /datum/material/gold = 4000, /datum/material/bluespace = 4000)
-	reagents_list = list(/datum/reagent/blood = 40)
 	build_path = /obj/item/borg/upgrade/modkit/bounty
 
 //Spooky special loot

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -538,7 +538,6 @@
 	id = "paint_remover"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 1000)
-	reagents_list = list(/datum/reagent/acetone = 60)
 	build_path = /obj/item/paint/paint_remover
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_JANITORIAL

--- a/modular_skyrat/modules/cellguns/code/medigun_research.dm
+++ b/modular_skyrat/modules/cellguns/code/medigun_research.dm
@@ -5,7 +5,6 @@
 	id = "brute2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
-	reagents_list = list(/datum/reagent/medicine/c2/libital = 10)
 	build_path = /obj/item/weaponcell/medical/brute/better
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -16,7 +15,6 @@
 	id = "burn2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
-	reagents_list = list(/datum/reagent/medicine/c2/aiuri = 10)
 	build_path = /obj/item/weaponcell/medical/burn/better
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -27,7 +25,6 @@
 	id = "toxin2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
-	reagents_list = list(/datum/reagent/medicine/c2/multiver = 10)
 	build_path = /obj/item/weaponcell/medical/toxin/better
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -38,7 +35,6 @@
 	id = "oxy2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
-	reagents_list = list(/datum/reagent/medicine/c2/convermol = 10)
 	build_path = /obj/item/weaponcell/medical/oxygen/better
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -50,7 +46,6 @@
 	id = "brute3medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
-	reagents_list = list(/datum/reagent/medicine/sal_acid = 10)
 	build_path = /obj/item/weaponcell/medical/brute/better/best
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -61,7 +56,6 @@
 	id = "burn3medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 3000, /datum/material/glass = 3000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
-	reagents_list = list(/datum/reagent/medicine/oxandrolone = 10)
 	build_path = /obj/item/weaponcell/medical/burn/better/best
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -72,7 +66,6 @@
 	id = "toxin3medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 3000, /datum/material/glass = 3000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
-	reagents_list = list(/datum/reagent/medicine/pen_acid = 10)
 	build_path = /obj/item/weaponcell/medical/toxin/better/best
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
@@ -84,7 +77,6 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
 	build_path = /obj/item/weaponcell/medical/oxygen/better/best
-	reagents_list = list(/datum/reagent/medicine/salbutamol = 10)
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -96,7 +88,6 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
 	build_path = /obj/item/weaponcell/medical/utility/clotting
-	reagents_list = list(/datum/reagent/medicine/salglu_solution = 5, /datum/reagent/blood = 5)
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -107,7 +98,6 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
 	build_path = /obj/item/weaponcell/medical/utility/temperature
-	reagents_list = list(/datum/reagent/medicine/leporazine = 10)
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -157,7 +147,6 @@
 	id = "relocatemedicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000, /datum/material/diamond = 500, /datum/material/bluespace = 2000)
-	reagents_list = list(/datum/reagent/eigenstate = 10)
 	build_path = /obj/item/weaponcell/medical/utility/relocation
 	category = list(RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL


### PR DESCRIPTION
still having required reagents is bad praxis, this was meant to be phased out. like two /tg/ designs still used it and we have sleepers anyways so medicells having them for free-ish isn't THAT unreasonable