### PR TITLE
[REVERT LATER(?)] Disables ALL Ghostroles (Asides From The Ghost Cafe)

### DIFF
--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -103,6 +103,7 @@
 	id = "hermitshack"
 	description = "A place of shelter for a lone hermit, scraping by to live another day."
 	suffix = "icemoon_underground_hermit.dmm"
+	unpickable = TRUE
 
 /datum/map_template/ruin/icemoon/underground/lavaland
 	name = "Lavaland Site"
@@ -135,6 +136,7 @@
 	Seem very intent on research and individual liberty, and also geology-based naming?"
 	prefix = "_maps/RandomRuins/AnywhereRuins/"
 	suffix = "golem_ship.dmm"
+	unpickable = TRUE
 
 /datum/map_template/ruin/icemoon/underground/mailroom
 	name = "Frozen-over Post Office"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -15,6 +15,7 @@
 	description = "Seemingly plucked from a tropical destination, this beach is calm and cool, with the salty waves roaring softly in the background. \
 	Comes with a rustic wooden bar and suicidal bartender."
 	suffix = "lavaland_biodome_beach.dmm"
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/biodome/winter
 	name = "Biodome Winter"
@@ -45,6 +46,7 @@
 	suffix = "lavaland_surface_seed_vault.dmm"
 	cost = 10
 	allow_duplicates = FALSE
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/ash_walker
 	name = "Ash Walker Nest"
@@ -53,8 +55,8 @@
 	Probably best to stay clear."
 	prefix = "_maps/RandomRuins/LavaRuins/skyrat/" // SKYRAT ADDITION
 	suffix = "lavaland_surface_ash_walker1_skyrat.dmm" // SKYRAT EDIT - ORIGINAL: lavaland_surface_ash_walker1.dmm
-	always_place = TRUE //SKYRAT EDIT CHANGE
-	allow_duplicates = FALSE
+	unpickable = TRUE
+
 //SKYRAT EDIT REMOVAL BEGIN - MAPPING
 /*
 /datum/map_template/ruin/lavaland/syndicate_base
@@ -75,6 +77,7 @@
 	prefix = "_maps/RandomRuins/AnywhereRuins/"
 	suffix = "golem_ship.dmm"
 	allow_duplicates = FALSE
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/gaia
 	name = "Patch of Eden"
@@ -215,6 +218,7 @@
 	suffix = "lavaland_surface_hermit.dmm"
 	allow_duplicates = FALSE
 	cost = 10
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/miningripley
 	name = "Ripley"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -200,6 +200,7 @@
 	suffix = "thederelict.dmm"
 	name = "Kosmicheskaya Stantsiya 13"
 	description = "The true fate of Kosmicheskaya Stantsiya 13 is an open question to this day. Most corporations deny its existence, for fear of questioning on what became of its crew."
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/abandonedteleporter
 	id = "abandonedteleporter"
@@ -228,6 +229,7 @@
 	name = "Syndicate Listening Station"
 	description = "Listening stations form the backbone of the syndicate's information-gathering operations. \
 	Assignment to these stations is dreaded by most agents, as it entails long and lonely shifts listening to nearby stations chatter incessantly about the most meaningless things."
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/old_ai_sat
 	id = "oldAIsat"
@@ -263,6 +265,7 @@
 	name = "Ancient Space Station"
 	description = "The crew of a space station awaken one hundred years after a crisis. Awaking to a derelict space station on the verge of collapse, and a hostile force of invading \
 	hivebots. Can the surviving crew overcome the odds and survive and rebuild, or will the cold embrace of the stars become their new home?"
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/gondoland
 	id = "gondolaasteroid"

--- a/modular_skyrat/modules/mapping/code/icemoon.dm
+++ b/modular_skyrat/modules/mapping/code/icemoon.dm
@@ -10,7 +10,7 @@
 	suffix = "icemoon_underground_syndicate_base1_skyrat.dmm"
 	allow_duplicates = FALSE
 	never_spawn_with = list(/datum/map_template/ruin/lavaland/skyrat/syndicate_base, /datum/map_template/ruin/rockplanet/syndicate_base)
-	always_place = TRUE
+	unpickable = TRUE
 
 /datum/map_template/ruin/icemoon/underground/skyrat/mining_site_below
 	name = "Mining Site Underground"
@@ -25,5 +25,4 @@
 	description = "A forboding dark stoned castle, it has seen better days but at least the current occupants patched the walls."
 	prefix = "_maps/RandomRuins/IceRuins/skyrat/"
 	suffix = "icemoon_underground_ash_walker1_skyrat.dmm"
-	always_place = TRUE
-	allow_duplicates = FALSE
+	unpickable = TRUE

--- a/modular_skyrat/modules/mapping/code/lavaland.dm
+++ b/modular_skyrat/modules/mapping/code/lavaland.dm
@@ -10,4 +10,4 @@
 	suffix = "lavaland_surface_syndicate_base1_skyrat.dmm"
 	allow_duplicates = FALSE
 	never_spawn_with = list(/datum/map_template/ruin/icemoon/underground/skyrat/syndicate_base, /datum/map_template/ruin/rockplanet/syndicate_base)
-	always_place = TRUE
+	unpickable = TRUE

--- a/modular_skyrat/modules/mapping/code/rockplanet.dm
+++ b/modular_skyrat/modules/mapping/code/rockplanet.dm
@@ -51,7 +51,7 @@
 	suffix = "rockplanet_surface_syndicate_base1_skyrat.dmm"
 	allow_duplicates = FALSE
 	never_spawn_with = list(/datum/map_template/ruin/icemoon/underground/skyrat/syndicate_base, /datum/map_template/ruin/lavaland/skyrat/syndicate_base)
-	always_place = TRUE
+	unpickable = TRUE
 
 //Below here should be ruins that are pretty much entirely fluff - minimal loot or threat, just adds to the aesthetic
 /datum/map_template/ruin/rockplanet/abandoned_a	//Restaraunt

--- a/modular_skyrat/modules/mapping/code/space.dm
+++ b/modular_skyrat/modules/mapping/code/space.dm
@@ -2,20 +2,12 @@
 /datum/map_template/ruin/space/skyrat
 	prefix = "_maps/RandomRuins/SpaceRuins/skyrat/"
 /*------*/
-/* //Disabled due to the existence of DS-2.
-/datum/map_template/ruin/space/skyrat/forgottenship
-	name = "CSBC-12"
-	id = "forgottenship"
-	description = "Cybersun would like to remind it's employees that any battle cruiser will be apropriately maintained, as will it's crew."
-	suffix = "forgottenship_skyrat.dmm"
-	always_place = TRUE
-*/
 /datum/map_template/ruin/space/skyrat/interdynefob
 	name = "DS-2"
 	id = "interdynefob"
 	description = "If DS-1 was so good..."
 	suffix = "interdynefob.dmm"
-	always_place = TRUE
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/skyrat/derelictferry
 	id = "derelictferry"
@@ -88,6 +80,7 @@
 	suffix = "blackmarket.dmm"
 	name = "Shady Market"
 	description = "Whaddya buyin'?"
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/skyrat/shuttle8532
 	id = "shuttle8532"
@@ -136,6 +129,7 @@
 	suffix = "cargodiselost.dmm"
 	name = "Cargodise Lost"
 	description = "A small crew of freight-haulers are marooned in space after pirates knock out their engines. They must survive off of the cargo on board their ship and fend off the pirate boarders on their ship."
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/skyrat/infestedntship
 	suffix = "scrapheap.dmm"
@@ -172,7 +166,7 @@
 	name = "Port Tarkon"
 	id = "escapefromtarkon"
 	description = "An ambitious goal, A step forward, A trial run for the Tarkon drill, ment to implant mining stations within meteors. Decades of disaster have, however, left this one... Unattended for far too long."
-	always_place = TRUE
+	unpickable = TRUE
 
 /obj/modular_map_root/port_tarkon
 	config_file = "strings/modular_maps/skyrat/PortTarkon.toml"


### PR DESCRIPTION
# Hey, wait, what!?
So, recently we had a round with 12 players online. Of these 12 players;
*3* were actually on the station. Several were on the lobby. The rest were in different ghostroles.
This is on top of an admin (headmin?) recommendation *and* a few players voicing the same.

We can policy police dumbasses on the research console. We *can't* do it with people being anti-social. As a result... funneling everyone we can into the station/ghost cafe is for the best.

## Hey, my character X is a ghostrole static, what do I do about it now?
Tl;dr;
- Syndicate statics can feasibly transition to the station without losing that affiliation. I'd highly recommend including a note about it in your records somewhere, so it's not just something only you know about.
- Ashwalker statics (All 2 of you, unironically) are unfortunately SOL at the moment, as they're too stronk to have on-station. If you're aware of a certain text panel related to me, you know I beleive this is tragic.
