### PR TITLE
{Testmerge until i can review more data from an actual round} Disables some events from the chaos SR system

### DIFF
--- a/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
@@ -69,7 +69,7 @@
 // LOW CHAOS EVENTS
 
 /datum/round_event_control/cortical_borer
-	chaos_level = EVENT_CHAOS_LOW
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/cme/minimal
 	chaos_level = EVENT_CHAOS_LOW
@@ -138,7 +138,7 @@
 	chaos_level = EVENT_CHAOS_LOW
 
 /datum/round_event_control/obsessed
-	chaos_level = EVENT_CHAOS_LOW
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/disease_outbreak
 	chaos_level = EVENT_CHAOS_LOW
@@ -147,7 +147,7 @@
 	chaos_level = EVENT_CHAOS_LOW
 
 /datum/round_event_control/morph
-	chaos_level = EVENT_CHAOS_LOW
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/supermatter_surge
 	chaos_level = EVENT_CHAOS_LOW
@@ -155,7 +155,7 @@
 // MODERATE CHAOS PRESETS
 
 /datum/round_event_control/cme/moderate
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/space_ninja
 	chaos_level = EVENT_CHAOS_MED
@@ -164,22 +164,22 @@
 	chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/nightmare
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/meteor_wave/meaty
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/meteor_wave/threatening
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/meteor_wave
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/immovable_rod
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/fugitives
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/sandstorm
 	chaos_level = EVENT_CHAOS_MED
@@ -188,32 +188,32 @@
 	chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/abductor
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/revenant
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /*
 *	HIGH CHAOS EVENTS
 */
 
 /datum/round_event_control/slaughter
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/alien_infestation
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/blob
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/pirates
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/space_dragon
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/resonance_cascade
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_DISABLED
 
 /datum/round_event_control/spacevine
 	chaos_level = EVENT_CHAOS_HIGH
@@ -222,7 +222,7 @@
 	chaos_level = EVENT_CHAOS_HIGH
 
 /datum/round_event_control/cme/extreme
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_DISABLED
 
 
 // RANDOM EVENTS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
With shifts now being greenshifts the SR system must be changed, this disables a number of them from rolling during the admin vote in the event panel. DO NOT SPEEDMERGE, if there are event problems i need to review some test logs from an actual round as im not spending 6 hours in a round with 30 empty bots
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
by the grace of allah remove this anteg reee, idfk yall asked me
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  https://pastebin.com/EWw2SVTU (this was a log of making some low, med, and high chaos admin votes, when not voted no event will roll due to it being a greenshift)
![image](https://user-images.githubusercontent.com/75702012/226499684-32a53cb9-2333-4cd7-ab85-7560440b672a.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance:disables 'highly destructive' and antag events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
