### PR TITLE
[FUCK] Makes RTG Boards Designs not C+V'd power cell Designs

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -21,6 +21,26 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
+/datum/design/board/rtg
+	name = "RTG generator board"
+	desc = "A basic RTG. Capable of produing a scalable amount of power depending on part tier, from 10kW to 40kW." // This doesn't account for WB-32 parts but'll be less confusing for people.
+	id = "rtgb"
+	build_path = /obj/item/circuitboard/machine/rtg
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/board/rtg_advanced
+	name = "Advanced RTG generator board"
+	desc = "A basic RTG. Capable of produing a scalable amount of power depending on part tier, from 25kW to 100kW."
+	id = "rtgbadv"
+	build_path = /obj/item/circuitboard/machine/rtg/advanced
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+
 /datum/design/board/announcement_system
 	name = "Automated Announcement System Board"
 	desc = "The circuit board for an automated announcement system."

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -2,32 +2,6 @@
 //////////////////Power/////////////////
 ////////////////////////////////////////
 
-/datum/design/rtg
-	name = "Basic 10 kw RTG generator board"
-	desc = "A basic RTG machine, capable of produing 10kw"
-	id = "rtgb"
-	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE |MECHFAB
-	materials = list(/datum/material/iron = 700, /datum/material/glass = 50)
-	construction_time=100
-	build_path = /obj/item/circuitboard/machine/rtg
-	category = list(
-		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
-
-/datum/design/rtgadv
-	name = "Advanced 25 kw RTG generator board"
-	desc = "An advanced RTG machine, capable of produing 25kw"
-	id = "rtgbadv"
-	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE |MECHFAB
-	materials = list(/datum/material/iron = 1400, /datum/material/glass = 50)
-	construction_time=100
-	build_path = /obj/item/circuitboard/machine/rtg/advanced
-	category = list(
-		RND_CATEGORY_STOCK_PARTS + RND_SUBCATEGORY_STOCK_PARTS_1
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
-
 /datum/design/basic_cell
 	name = "Basic Power Cell"
 	desc = "A basic power cell that holds 1 MJ of energy."


### PR DESCRIPTION
This has been bothering me forever, it's the one board design you can't make in a circuit imprinter (but can make anywhere else?)
This fixes that, along with moving it's material cost and buildspeed in line with the others.

Also clarifies just how much power both can generate.