### PR TITLE
[REQ] Ion Mecha Thrusters

### DIFF
--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -699,6 +699,36 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
+/datum/design/ion_mech_thrusters
+	name = "Ion Thruster Package"
+	desc = "A thruster package for exosuits. Uses electricity to generate thrust."
+	id = "ion_mech_thrusters"
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/mecha_equipment/thrusters/ion
+	materials = list(/datum/material/iron=25000,/datum/material/titanium=5000,/datum/material/diamond=3000)
+	construction_time = 100
+	category = list(
+		RND_CATEGORY_MECHFAB_EQUIPMENT,
+		RND_CATEGORY_MECHFAB_RIPLEY,
+		RND_CATEGORY_MECHFAB_ODYSSEUS,
+		RND_CATEGORY_MECHFAB_GYGAX,
+		RND_CATEGORY_MECHFAB_DURAND,
+		RND_CATEGORY_MECHFAB_HONK,
+		RND_CATEGORY_MECHFAB_PHAZON,
+		RND_CATEGORY_MECHFAB_CLARKE
+	)
+	category = list(
+		RND_CATEGORY_MECHFAB_EQUIPMENT + RND_SUBCATEGORY_MECHFAB_EQUIPMENT_MODULES,
+		RND_CATEGORY_MECHFAB_RIPLEY + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
+		RND_CATEGORY_MECHFAB_ODYSSEUS + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
+		RND_CATEGORY_MECHFAB_GYGAX + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
+		RND_CATEGORY_MECHFAB_DURAND + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
+		RND_CATEGORY_MECHFAB_HONK + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
+		RND_CATEGORY_MECHFAB_PHAZON + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT,
+		RND_CATEGORY_MECHFAB_CLARKE + RND_SUBCATEGORY_MECHFAB_SUPPORTED_EQUIPMENT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
 /datum/design/mech_gravcatapult
 	name = "Gravitational Catapult Module"
 	desc = "An exosuit mounted Gravitational Catapult."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1607,7 +1607,7 @@
 	id = "adv_weaponry"
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
-	prereq_ids = list("adv_engi", "weaponry")
+	prereq_ids = list("adv_engi", "weaponry", "adv_mecha")
 	design_ids = list(
 		"pin_loyalty",
 		"ammo_workbench",//SKYRAT EDIT ADDITION
@@ -1623,6 +1623,7 @@
 		"norwindkit",
 		"zetakit",
 		"fireflykit",
+		"ion_mech_thrusters",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -71,7 +71,7 @@
 	equip_by_category = list(
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot,
 		MECHA_R_ARM = null,
-		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion/internal),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(/obj/item/mecha_parts/mecha_equipment/armor/anticcw_armor_booster, /obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster),
 	)

--- a/code/modules/vehicles/mecha/combat/honker.dm
+++ b/code/modules/vehicles/mecha/combat/honker.dm
@@ -50,7 +50,7 @@
 	equip_by_category = list(
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/honker,
 		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar/bombanana,
-		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion/internal),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(),
 	)

--- a/code/modules/vehicles/mecha/combat/marauder.dm
+++ b/code/modules/vehicles/mecha/combat/marauder.dm
@@ -32,7 +32,7 @@
 	equip_by_category = list(
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
 		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
-		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion/internal),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(/obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster),
 	)
@@ -93,7 +93,7 @@
 	equip_by_category = list(
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
 		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
-		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion/internal),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(/obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster),
 	)
@@ -114,7 +114,7 @@
 	equip_by_category = list(
 		MECHA_L_ARM = null,
 		MECHA_R_ARM = null,
-		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion/internal),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(),
 	)
@@ -124,7 +124,7 @@
 	equip_by_category = list(
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
 		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
-		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters/ion/internal),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(/obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster),
 	)

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -455,10 +455,9 @@
 	generate_effect(movement_dir)
 	return TRUE
 
-/obj/item/mecha_parts/mecha_equipment/thrusters/ion //for mechs with built-in thrusters, should never really exist un-attached to a mech
+/obj/item/mecha_parts/mecha_equipment/thrusters/ion
 	name = "Ion thruster package"
 	desc = "A set of thrusters that allow for exosuit movement in zero-gravity environments."
-	detachable = FALSE
 	effect_type = /obj/effect/particle_effect/ion_trails
 
 /obj/item/mecha_parts/mecha_equipment/thrusters/ion/thrust(movement_dir)
@@ -468,6 +467,10 @@
 		generate_effect(movement_dir)
 		return TRUE
 	return FALSE
+
+/obj/item/mecha_parts/mecha_equipment/thrusters/ion/internal //for mechs with built-in thrusters, should never really exist un-attached to a mech
+	name = "internal ion thruster package"
+	detachable = FALSE
 
 ///////////////////////////////////// CONCEALED WEAPON BAY ////////////////////////////////////////
 


### PR DESCRIPTION
Debated on how to do this but ultimately decided they should be base tech.

- Separates Ion Thrusters into two types: Internal and External. Internal are the kind that comes stock on Nukie/CC Mechs, External are...
- The printable kind. Middlingly expensive, not very compared to the rest of assembling a mech.
- To slot them in effectively, advanced weapons tech now required advanced mecha tech. (This does mean that advanced weaponry is locked behind biotech, but if you aren't doing dissections, you don't deserve gamer guns methinks.)