### PR TITLE
implements the unused masturbation item as an emote, triggered by *jerk

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -138,6 +138,23 @@
 		qdel(N)
 		to_chat(user, span_warning("You're incapable of slapping in your current state."))
 
+/datum/emote/living/carbon/jerk
+	key = "jerk"
+	key_third_person = ""
+	hands_use_check = TRUE
+	cooldown = 10 SECONDS // jerk it #'w '#
+
+/datum/emote/living/carbon/jerk/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/hand_item/coom/JERK = new(user)
+	if(user.put_in_hands(JERK))
+		to_chat(user, span_notice("You ready your jerking hand."))
+	else
+		qdel(JERK)
+		to_chat(user, span_warning("You're incapable of jerking in your current state."))
+
 
 /datum/emote/living/carbon/hand
 	key = "hand"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

_"I get sad, and I do a spicy *jerk"_
Implements the unused "coom" hand_item which allows the player to masturbate and "coom" into containers, on people, items and themselves with their penis.

## How This Contributes To The T.E Station Roleplay Experience

Cum sluts can enjoy their favorite beverage in a wine glass. (mmm fancy)
![image](https://github.com/JasmineRickards/T.E.-station/assets/128428189/6fa811f9-b047-4cdf-8255-f16e7889a42e)
A chef can make some new, salty condiments. (*chefkiss)
![image](https://github.com/JasmineRickards/T.E.-station/assets/128428189/fa5f567e-9b43-4023-8c82-965fd7854832)
Overall, the fact that we can't collect coom properly normally is an unforgivable sin, which can only be absolved by merging this commit.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/JasmineRickards/T.E.-station/assets/128428189/26556393-4871-4e13-b958-aa57e81d9331)

![image](https://github.com/JasmineRickards/T.E.-station/assets/128428189/fee989ad-5897-4e81-adc8-0f9bca9c849a)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: implemented the unused masturbation hand item, activated with *jerk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
