### PR TITLE
gigantism and dwarfism fixes.

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -120,27 +120,26 @@
 	if(..())
 		return
 	// SKYRAT EDIT BEGIN
-	if(owner.dna.features["body_size"] < 1)
-		to_chat(owner, "You feel your body shrinking even further, but your organs aren't! Uh oh!")
-		owner.adjustBruteLoss(25)
-		return
+	// if(owner.dna.features["body_size"] < 1) Again, no reason to nuke someone for just having the trait >:(
+	// 	to_chat(owner, "You feel your body shrinking even further, but your organs aren't! Uh oh!")
+	// 	owner.adjustBruteLoss(25)
+	// 	return
 	// SKYRAT EDIT END
 	ADD_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
-	var/matrix/new_transform = matrix()
-	new_transform.Scale(1, 0.8)
-	owner.transform = new_transform.Multiply(owner.transform)
-	passtable_on(owner, GENETIC_MUTATION)
-	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
+	if(!owner.normalized)
+		owner.resize = 0.8
+		owner.update_transform()
+		owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
+
 
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
-	var/matrix/new_transform = matrix()
-	new_transform.Scale(1, 1.25)
-	owner.transform = new_transform.Multiply(owner.transform)
-	passtable_off(owner, GENETIC_MUTATION)
-	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
+	if(!owner.normalized)
+		owner.resize = 1.25
+		owner.update_transform()
+		owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
 
 //Clumsiness has a very large amount of small drawbacks depending on item.
 /datum/mutation/human/clumsy
@@ -394,23 +393,25 @@
 	if(..())
 		return
 	// SKYRAT EDIT BEGIN
-	if(owner.dna.features["body_size"] > 1)
-		to_chat(owner, "You feel your body expanding even further, but it feels like your bones are expanding too much!")
-		owner.adjustBruteLoss(25) // take some DAMAGE
-		return
+	// if(owner.dna.features["body_size"] > 1) NO REASON to make it fail and punish you. - luke vale.
+	// 	to_chat(owner, "You feel your body expanding even further, but it feels like your bones are expanding too much!")
+	// 	owner.adjustBruteLoss(25) // take some DAMAGE
+	// 	return
 	// SKYRAT EDIT END
 	ADD_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
-	owner.resize = 1.25
-	owner.update_transform()
-	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
+	if(!owner.normalized)
+		owner.resize = 1.25
+		owner.update_transform()
+		owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
 
 /datum/mutation/human/gigantism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
-	owner.resize = 0.8
-	owner.update_transform()
-	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
+	if(!owner.normalized)
+		owner.resize = 0.8
+		owner.update_transform()
+		owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
 /datum/mutation/human/spastic
 	name = "Spastic"

--- a/code/modules/clothing/sizeclothing.dm
+++ b/code/modules/clothing/sizeclothing.dm
@@ -3,6 +3,8 @@
 	var/normalize_size = 1 //This number is used as the "normal" height people will be given when wearing one of these accessories
 	var/natural_size = null //The value of the wearer's body_size var in prefs. Unused for now.
 	var/recorded_size = null //the user's height prior to equipping
+	///Used to keep track if we have the gigantism or dwarfism for use in the size clothing.
+	var/macro_or_micro = 0 // 1 = dwarf 2 = giant
 
 //For applying a normalization
 /obj/item/clothing/proc/normalize_mob_size(mob/living/carbon/human/H)
@@ -20,18 +22,41 @@
 	H.visible_message("<span class='warning'>A flash of purple light engulfs [H], before they change to normal!</span>","<span class='notice'>You feel warm for a moment, before everything scales to your size...</span>")
 	H.set_size(normalize_size) //Then apply the size
 	H.normalized = TRUE //And set normalization
-
+	if(HAS_TRAIT(H, TRAIT_GIANT))
+		macro_or_micro = 2
+	if(HAS_TRAIT(H, TRAIT_DWARF))
+		macro_or_micro = 1
 //For removing a normalization, and reverting back to normal
 /obj/item/clothing/proc/denormalize_mob_size(mob/living/carbon/human/H)
 	if(!recorded_size)
 		return
+
+	if(!macro_or_micro)
+		if(HAS_TRAIT(H, TRAIT_GIANT))
+			recorded_size *= 1.25
+		else if(HAS_TRAIT(H, TRAIT_DWARF))
+			recorded_size *= 0.8
+	else if(macro_or_micro == 1)
+		if(!HAS_TRAIT(H, TRAIT_DWARF))
+			recorded_size *= 1.25
+			macro_or_micro = 0
+		if(HAS_TRAIT(H, TRAIT_GIANT))
+			recorded_size *= 1.25
+			macro_or_micro = 2
+	else
+		if(!HAS_TRAIT(H, TRAIT_GIANT))
+			recorded_size *= 0.8
+		if(HAS_TRAIT(H, TRAIT_DWARF))
+			recorded_size *= 0.8
+
 	if(H.normalized) //sanity check
 		playsound(H,'sound/weapons/emitter2.ogg', 50, 1)
 		flash_lighting_fx(3, 3, LIGHT_COLOR_YELLOW)
 		H.visible_message("<span class='warning'>Golden light engulfs [H], and they shoot back to their default height!</span>","<span class='notice'>Energy rushes through your body, and you return to normal.</span>")
 		H.set_size(recorded_size)
 		H.normalized = FALSE
-		recorded_size = null
+	recorded_size = null
+
 
 //For storing normalization on mobs
 /mob/living

--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -152,7 +152,7 @@
 
 			//scaling
 			var/atom/movable/owned_turf = user.owned_turf
-			var/change_multiplier = human_user.dna.features["body_size"] / BODY_SIZE_NORMAL
+			var/change_multiplier = human_user.size_multiplier // just grabs our current body size for use in this.
 			var/translate = ((change_multiplier-1) * 32)/2
 			owned_turf.transform = owned_turf.transform.Scale(change_multiplier)
 			owned_turf.transform = owned_turf.transform.Translate(0, translate)

--- a/modular_skyrat/modules/size_gear/code/size_gear.dm
+++ b/modular_skyrat/modules/size_gear/code/size_gear.dm
@@ -13,8 +13,18 @@
     sizechange(user)
 
 /obj/item/sizebrick/proc/sizechange(mob/living/carbon/human/H)
+    if(H.normalized)
+        to_chat(H, "<span class='warning'>The devices buzzes, refusing to change you while being normalized.</span>")
+        playsound(H, 'sound/machines/buzz-sigh.ogg', 50, 1)
+        return
     var/size_select = tgui_input_number(usr, "Put the desired size (60-300%)", "Set Size", 100, 300, 60)
+    var/size_adjust = 1
+    if (HAS_TRAIT(H, TRAIT_DWARF))
+        size_adjust = 0.8
+    if (HAS_TRAIT(H, TRAIT_GIANT))
+        size_adjust = 1.25
     size_select /= 100
+    size_select *= size_adjust
     if (H.size_multiplier == size_select)
         to_chat(H, "<span class='warning'>The devices buzzes, your selected size is the same as your current.</span>")
         playsound(H, 'sound/machines/buzz-sigh.ogg', 50, 1)


### PR DESCRIPTION
Fixes the giant and dwarf mutations so they can't be exploited when used with the normalizer. Also makes it so the resizer takes it into account for size adjustment.

Also fixes the *turf emote tail sprite scaling. Scaling to character scale rather then your size in prefrences.